### PR TITLE
Add audited Alert Rule configuration (Phase 3A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .superpowers/sdd/
 .serena/
 .Codex/
+.worktrees/
 .pytest_cache/
 .terraform/
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Limnopulse
 
-FastAPI foundation for Limnopulse with Phase 2A authorized telemetry read endpoints.
+FastAPI foundation for Limnopulse with authorized telemetry reads and Phase 3A Alert Rule configuration.
 
 ## Local Setup
 
@@ -12,7 +12,7 @@ python -m venv .venv
 . .venv/bin/activate
 pip install -e ".[dev]"
 docker compose up -d redis dynamodb-local influxdb mqtt-broker telegraf
-# creates LimnopulseDomain and LimnopulseAudit locally
+# creates LimnopulseDomain and LimnopulseAudit and enables expires_at TTL
 python scripts/dev/init_dynamodb.py
 python scripts/dev/seed_local.py
 python -m uvicorn limnopulse_api.main:app --reload --host 0.0.0.0 --port 8000
@@ -38,7 +38,44 @@ GET /v1/tenants/{tenant_id}/ponds/{pond_id}/readings?start=-1h&limit=500
 GET /v1/tenants/{tenant_id}/ponds/{pond_id}/metrics/latest
 ```
 
-The API checks active tenant membership and verifies the pond in DynamoDB before querying InfluxDB. Clients never access InfluxDB directly. Go workers, alerts, and notification channels are not implemented yet.
+The API checks active tenant membership and verifies the pond in DynamoDB before querying InfluxDB. Clients never access InfluxDB directly. Go alert evaluation and notification delivery are not implemented yet.
+
+## Alert Rules
+
+Phase 3A exposes tenant-scoped rule configuration:
+
+```text
+GET   /v1/tenants/{tenant_id}/alert-rules
+POST  /v1/tenants/{tenant_id}/alert-rules
+PATCH /v1/tenants/{tenant_id}/alert-rules/{rule_id}
+POST  /v1/tenants/{tenant_id}/alert-rules/{rule_id}/replace
+```
+
+All active tenant roles may list rules. Only owner and admin roles may create, patch, or replace them. Creation validates that the pond exists and that an optional device belongs to the same tenant and pond.
+
+Example creation body:
+
+```json
+{
+  "pond_id": "pond_001",
+  "device_id": "dev_001",
+  "metric": "do_mg_l",
+  "name": "Low dissolved oxygen",
+  "operator": "<",
+  "threshold": 5.0,
+  "aggregation": "min",
+  "window": "5m",
+  "duration": "3m",
+  "severity": "critical",
+  "channels": ["email", "telegram"],
+  "cooldown_seconds": 1800,
+  "enabled": true
+}
+```
+
+PATCH accepts `expected_version` plus at least one mutable field. Tenant, pond, optional device, and metric form the semantic identity and cannot be patched. To change identity, call `/replace` with a complete replacement body, `expected_version`, and an `Idempotency-Key` header between 8 and 128 characters. The same key and payload replays the result for 24 hours; reusing the key with another payload returns `409`.
+
+This phase stores channel declarations but does not evaluate telemetry or send notifications. See `docs/architecture.md` for the Phase 3B evaluator and Phase 3C dispatcher boundaries.
 
 ## Local Telemetry Ingestion
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,161 @@
+# Limnopulse Architecture
+
+**Version:** 1.1
+**Updated:** 2026-07-15
+
+Limnopulse is the successor to the AquaFarm prototype. AquaFarm names in historical material describe the predecessor only; all active resources, topics, buckets, code, and new documentation use the Limnopulse name.
+
+## Delivery status
+
+| Slice | Status | Delivered boundary |
+|---|---|---|
+| Phase 1 | Current | FastAPI, Cognito/dev authentication, tenant membership authorization, tenants, ponds, devices, DynamoDB, Redis cache-aside |
+| Phase 2A | Current | authorized InfluxDB telemetry reads |
+| Phase 2B/2C | Current local scaffold | MQTT, Telegraf, local registry enrichment, InfluxDB writes |
+| Phase 2D | Current scaffold | OpenTofu for DynamoDB, Cognito, SQS/DLQ, and optional SES identity |
+| Phase 3A | Current | Alert Rule configuration, optimistic updates, replacement idempotency, transactional audit, TTL |
+| Phase 3B | Target | Go evaluator, InfluxDB window evaluation, Redis cooldown/deduplication, Alert Events |
+| Phase 3C | Target | SQS notification dispatcher, SES/Telegram delivery, retries, delivery records |
+
+“Current” means implemented in this repository. “Target” is architectural direction and must not be interpreted as a deployed capability.
+
+## System view
+
+```mermaid
+flowchart LR
+    Sensor[Sensor / Gateway] -->|MQTT QoS 1| Broker[MQTT Broker]
+    Broker --> Telegraf
+    Telegraf --> Influx[(InfluxDB)]
+
+    User[Web / Mobile User] -->|Cognito access token| API[FastAPI]
+    API --> Dynamo[(LimnopulseDomain)]
+    API --> Audit[(LimnopulseAudit)]
+    API --> Redis[(Redis cache)]
+    API --> Influx
+
+    Influx -. Phase 3B .-> Evaluator[Go Alert Evaluator]
+    Dynamo -. Phase 3B .-> Evaluator
+    Redis -. Phase 3B .-> Evaluator
+    Evaluator -. Phase 3C .-> Queue[SQS]
+    Queue -. Phase 3C .-> Dispatcher[Go Notification Dispatcher]
+    Dispatcher -.-> SES
+    Dispatcher -.-> Telegram
+```
+
+Solid edges are present repository responsibilities or local scaffolds. Dotted edges are later alert phases.
+
+## Canonical names
+
+### MQTT
+
+```text
+limnopulse/v1/devices/{device_id}/readings
+limnopulse/v1/devices/{device_id}/health
+```
+
+Devices publish their identity and sensor readings. Tenant and pond ownership are resolved by trusted registry enrichment; tenant IDs, credentials, and tokens do not belong in device payloads or topic names.
+
+### InfluxDB
+
+| Bucket | Purpose | Status |
+|---|---|---|
+| `limnopulse_raw` | authorized raw water-quality readings | current |
+| `limnopulse_1h` | long-retention hourly aggregates | target |
+| `limnopulse_events` | lightweight operational time-series events | target |
+
+The `water_quality` measurement uses `tenant_id`, `pond_id`, `device_id`, `source`, and `schema_version` tags. Sensor values remain fields.
+
+### DynamoDB
+
+```text
+LimnopulseDomain
+LimnopulseAudit
+```
+
+Both tables use string `PK` and `SK`, on-demand billing, encryption, point-in-time recovery in cloud infrastructure, and TTL on the numeric `expires_at` attribute. DynamoDB TTL deletion is eventual, so application logic treats expired records as expired before physical deletion.
+
+Core `LimnopulseDomain` keys:
+
+| Entity | PK | SK |
+|---|---|---|
+| Tenant | `TENANT#<tenant_id>` | `META` |
+| Pond | `TENANT#<tenant_id>` | `POND#<pond_id>` |
+| Device | `TENANT#<tenant_id>` | `DEVICE#<device_id>` |
+| Device lookup | `DEVICE#<device_id>` | `META` |
+| Membership | `USER#<cognito_sub>` | `TENANT#<tenant_id>` |
+| Tenant member | `TENANT#<tenant_id>` | `MEMBER#<cognito_sub>` |
+| Alert Rule | `TENANT#<tenant_id>` | `ALERT_RULE#<rule_id>` |
+| Alert Rule replacement replay | `TENANT#<tenant_id>` | `IDEMPOTENCY#ALERT_RULE_REPLACE#<sha256>` |
+
+Critical list paths use `Query` or known-key reads. Application code does not use DynamoDB `Scan`.
+
+Audit keys:
+
+```text
+PK = TENANT#<tenant_id>#MONTH#YYYY-MM
+SK = <UTC timestamp>#<audit event id>
+```
+
+Audit records retain actor, action, resource, before/after SHA-256 hashes, IP, user agent, creation time, and 90-day expiry. They never store JWTs, credentials, or mutation payloads.
+
+## Authentication and tenant authorization
+
+The access token authenticates a user; it does not grant tenant access by itself. Every tenant route resolves an active DynamoDB membership and then enforces the required role.
+
+```text
+JWT or local dev identity
+  -> active tenant membership
+  -> role check
+  -> tenant-scoped repository access
+```
+
+Owner and admin roles may mutate Alert Rules. Member and viewer roles may list them.
+
+## Phase 3A: Alert Rule configuration
+
+Alert Rule identity consists of tenant, pond, optional device, and metric. These fields cannot be patched. Mutable fields are name, operator, threshold, aggregation, window, duration, severity, channels, cooldown, and enabled state.
+
+Supported metric values:
+
+```text
+temp_c
+ph
+do_mg_l
+turbidity_ntu
+salinity_ppt
+battery_v
+rssi
+```
+
+Rules support `<`, `<=`, `>`, and `>=`; `min`, `max`, `mean`, and `last`; warning/critical severity; and email/Telegram channel declarations. Channel declarations are configuration only in Phase 3A.
+
+Windows and durations use compact values from 60 seconds through 24 hours, such as `60s`, `5m`, and `24h`. Cooldown is 60 through 86,400 seconds.
+
+Changing semantic identity uses the replace endpoint. One DynamoDB transaction disables and versions the old rule, links both records, creates the replacement, records audit, and stores a 24-hour replay result. The same `Idempotency-Key` and payload returns that result; a different payload with the same key returns `409`.
+
+## Phase 3B: evaluation target
+
+The future Go evaluator will:
+
+1. read active rules from `LimnopulseDomain`;
+2. query bounded InfluxDB windows;
+3. apply aggregation/operator thresholds;
+4. use Redis only for cooldown and short deduplication;
+5. atomically create Alert Events;
+6. enqueue notification jobs.
+
+Phase 3B does not change the Phase 3A API identity or replacement contract.
+
+## Phase 3C: delivery target
+
+The future notification dispatcher will consume SQS with a DLQ, apply retry and permanent-failure policies, resolve verified preferences, send through SES and Telegram, and persist delivery attempts. WhatsApp, SMS, and mobile push remain later commercial/product decisions.
+
+## Security boundaries
+
+- InfluxDB, Redis, and DynamoDB are service-side resources; clients do not connect directly.
+- Redis is cache/ephemeral coordination, never source of truth or durable queue.
+- Production MQTT requires TLS/mTLS, per-device credentials, and topic ACLs.
+- Tenant/pond/device target mismatches return `404` to avoid cross-tenant disclosure.
+- Conditional writes and expected versions prevent silent lost updates.
+- Secrets, raw tokens, and idempotency keys are excluded from domain/audit records.
+- IAM, network exposure, real remote state, and secret management require environment-specific hardening before production deployment.

--- a/docs/superpowers/plans/2026-07-15-limnopulse-phase-3a-alert-rules.md
+++ b/docs/superpowers/plans/2026-07-15-limnopulse-phase-3a-alert-rules.md
@@ -1,0 +1,355 @@
+# Limnopulse Phase 3A Alert Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add tenant-scoped, audited, optimistic, and idempotently replaceable Alert Rules to the FastAPI/DynamoDB domain.
+
+**Architecture:** A focused `AlertRuleRepository` protocol separates alert persistence from the existing domain repository. `AlertRuleService` validates tenant pond/device targets and generates IDs, while `DynamoAlertRuleRepository` owns DynamoDB Query and cross-table transactional writes for rules, audits, and replacement idempotency. FastAPI schemas reject extra input and routers reuse tenant membership authorization.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic 2, boto3 DynamoDB low-level client, pytest, OpenTofu with AWS Provider 6.x.
+
+## Global Constraints
+
+- Metrics are exactly `temp_c`, `ph`, `do_mg_l`, `turbidity_ntu`, `salinity_ppt`, `battery_v`, and `rssi`.
+- Operators are exactly `<`, `<=`, `>`, and `>=`; aggregations are `min`, `max`, `mean`, and `last`.
+- Severities are `warning` and `critical`; channels are `email` and `telegram`.
+- `window` and `duration` are compact duration strings bounded from 60 seconds through 24 hours.
+- `cooldown_seconds` is bounded from 60 through 86,400.
+- Only owner/admin may mutate; all active tenant roles may list.
+- DynamoDB list access uses `Query`, never `Scan`.
+- Audit retention is 90 days; replacement idempotency retention is 24 hours.
+- No AlertEvent, evaluator, Redis cooldown, SQS dispatch, SES, or Telegram integration is implemented in Phase 3A.
+
+---
+
+### Task 1: Alert Rule domain and repository contracts
+
+**Files:**
+- Create: `src/limnopulse_api/domain/alerts.py`
+- Modify: `src/limnopulse_api/domain/ids.py`
+- Create: `src/limnopulse_api/repositories/alerts.py`
+- Test: `tests/unit/test_alert_rule_domain.py`
+
+**Interfaces:**
+- Produces: `AlertMetric`, `AlertOperator`, `AlertAggregation`, `AlertSeverity`, `AlertChannel`, `AlertRule`, `AuditContext`, `AlertRuleReplacement`, `AlertRuleRepository`, `new_alert_rule_id()`.
+- `AlertRuleRepository` methods are `list_rules(tenant_id)`, `create_rule(rule, audit)`, `update_rule(tenant_id, rule_id, expected_version, updates, audit)`, `get_replacement_replay(tenant_id, idempotency_key, request_hash)`, and `replace_rule(tenant_id, rule_id, expected_version, replacement, idempotency_key, request_hash, audit)`.
+
+- [x] **Step 1: Write failing domain tests**
+
+```python
+def test_alert_rule_rejects_duration_outside_bounds() -> None:
+    with pytest.raises(ValidationError):
+        make_rule(window="59s")
+
+
+def test_new_alert_rule_id_has_canonical_prefix() -> None:
+    assert re.fullmatch(r"rule_[0-9a-f]{32}", new_alert_rule_id())
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_alert_rule_domain.py -q`
+
+Expected: collection fails because `limnopulse_api.domain.alerts` does not exist.
+
+- [x] **Step 3: Implement immutable domain types and protocol**
+
+```python
+class AlertRule(VersionedEntity):
+    tenant_id: str
+    rule_id: str
+    pond_id: str
+    device_id: str | None = None
+    metric: AlertMetric
+    name: str
+    operator: AlertOperator
+    threshold: float
+    aggregation: AlertAggregation
+    window: AlertDuration
+    duration: AlertDuration
+    severity: AlertSeverity
+    channels: tuple[AlertChannel, ...]
+    cooldown_seconds: int
+    enabled: bool
+    replaces_rule_id: str | None = None
+    replaced_by_rule_id: str | None = None
+```
+
+- [x] **Step 4: Run domain tests and verify GREEN**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_alert_rule_domain.py -q`
+
+Expected: all Task 1 tests pass.
+
+- [x] **Step 5: Commit**
+
+Run: `git add src/limnopulse_api/domain/alerts.py src/limnopulse_api/domain/ids.py src/limnopulse_api/repositories/alerts.py tests/unit/test_alert_rule_domain.py && git commit -m "feat: define alert rule domain"`
+
+### Task 2: DynamoDB Alert Rule adapter
+
+**Files:**
+- Create: `src/limnopulse_api/adapters/alert_rules.py`
+- Test: `tests/unit/test_alert_rule_repository.py`
+- Modify: `tests/unit/test_no_scan_guard.py`
+
+**Interfaces:**
+- Consumes: Task 1 domain types and protocol.
+- Produces: `DynamoAlertRuleRepository(domain_table_name, audit_table_name, client, clock=utc_now)`.
+- Persists rule keys as `TENANT#<tenant_id>` / `ALERT_RULE#<rule_id>` and audit keys as `TENANT#<tenant_id>#MONTH#YYYY-MM` / `<timestamp>#<event_id>`.
+
+- [x] **Step 1: Write failing Query/create transaction tests**
+
+```python
+@pytest.mark.asyncio
+async def test_list_rules_queries_alert_rule_prefix_without_scan() -> None:
+    rules = await repository.list_rules("tnt_1")
+    assert rules == []
+    assert client.query_calls[0]["KeyConditionExpression"] == "PK = :pk AND begins_with(SK, :sk_prefix)"
+    assert client.scan_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_create_rule_atomically_puts_rule_and_redacted_audit() -> None:
+    created = await repository.create_rule(rule, audit_context)
+    transaction = client.transact_write_items_calls[0]["TransactItems"]
+    assert created.version == 1
+    assert [item["Put"]["TableName"] for item in transaction] == ["LimnopulseDomain", "LimnopulseAudit"]
+```
+
+- [x] **Step 2: Run adapter tests and verify RED**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_alert_rule_repository.py -q`
+
+Expected: collection fails because the adapter does not exist.
+
+- [x] **Step 3: Implement Query, serialization, hashing, and atomic create**
+
+The adapter uses `TypeSerializer`/`TypeDeserializer`, paginates `Query` with `LastEvaluatedKey`, hashes canonical JSON via SHA-256, and writes mutation audit entries in the same `TransactWriteItems` call as the rule.
+
+- [x] **Step 4: Run focused tests and verify GREEN**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_alert_rule_repository.py -q`
+
+Expected: list and create tests pass.
+
+- [x] **Step 5: Write failing optimistic PATCH tests**
+
+```python
+@pytest.mark.asyncio
+async def test_update_rule_conditions_on_version_and_writes_audit() -> None:
+    updated = await repository.update_rule("tnt_1", "rule_1", 2, {"threshold": 4.5}, audit_context)
+    assert updated.version == 3
+    assert updated.threshold == 4.5
+    assert len(client.transact_write_items_calls[0]["TransactItems"]) == 2
+```
+
+- [x] **Step 6: Implement conditional PATCH and conflict mapping**
+
+The rule update condition is `attribute_exists(PK) AND attribute_exists(SK) AND #version = :expected_version AND #status = :active`; only supplied mutable fields are included in the `SET` expression.
+
+- [x] **Step 7: Write failing replacement replay/conflict tests**
+
+```python
+@pytest.mark.asyncio
+async def test_replace_rule_is_atomic_and_replays_same_request() -> None:
+    first = await repository.replace_rule("tnt_1", "rule_old", 1, replacement, "request-123", request_hash, audit_context)
+    replay = await repository.replace_rule("tnt_1", "rule_old", 1, replacement, "request-123", request_hash, audit_context)
+    assert replay == first
+    assert len(client.transact_write_items_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_replace_rule_rejects_idempotency_key_reuse_with_other_payload() -> None:
+    await repository.replace_rule("tnt_1", "rule_old", 1, replacement, "request-123", request_hash, audit_context)
+    with pytest.raises(ConflictError):
+        await repository.replace_rule("tnt_1", "rule_old", 1, other_replacement, "request-123", other_hash, audit_context)
+```
+
+- [x] **Step 8: Implement atomic replacement and 24-hour idempotency**
+
+The transaction updates the old rule, puts the replacement, puts one audit record, and puts an idempotency result conditioned on absence or expiry. Stored response snapshots allow exact replay while a mismatched request hash raises `ConflictError`.
+
+- [x] **Step 9: Run adapter and no-scan tests and commit**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_alert_rule_repository.py tests/unit/test_no_scan_guard.py -q`
+
+Expected: all Task 2 tests pass.
+
+Run: `git add src/limnopulse_api/adapters/alert_rules.py tests/unit/test_alert_rule_repository.py tests/unit/test_no_scan_guard.py && git commit -m "feat: persist audited alert rules"`
+
+### Task 3: Service, schemas, dependencies, and routes
+
+**Files:**
+- Create: `src/limnopulse_api/services/alert_rules.py`
+- Create: `src/limnopulse_api/api/v1/schemas/alert_rules.py`
+- Create: `src/limnopulse_api/api/v1/routers/alert_rules.py`
+- Modify: `src/limnopulse_api/api/dependencies.py`
+- Modify: `src/limnopulse_api/api/router.py`
+- Modify: `src/limnopulse_api/main.py`
+- Test: `tests/api/test_alert_rules.py`
+
+**Interfaces:**
+- Consumes: `DomainRepository`, `AlertRuleRepository`, `TenantAccess`, and Task 1 types.
+- Produces: `AlertRuleService`, `AlertRuleCreate`, `AlertRuleUpdate`, `AlertRuleReplace`, `AlertRuleResponse`, `AlertRuleListResponse`, and `AlertRuleReplacementResponse`.
+
+- [x] **Step 1: Write failing API authorization and validation tests**
+
+```python
+def test_viewer_can_list_but_cannot_create_alert_rules() -> None:
+    assert client.get(path, headers=headers).status_code == 200
+    assert client.post(path, json=create_payload, headers=headers).status_code == 403
+
+
+def test_patch_rejects_empty_or_immutable_changes() -> None:
+    assert client.patch(rule_path, json={"expected_version": 1}, headers=headers).status_code == 422
+    assert client.patch(rule_path, json={"expected_version": 1, "metric": "ph"}, headers=headers).status_code == 422
+```
+
+- [x] **Step 2: Run API tests and verify RED**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/api/test_alert_rules.py -q`
+
+Expected: requests return `404` because the router is not registered.
+
+- [x] **Step 3: Implement strict schemas, service validation, dependencies, and list/create/PATCH routes**
+
+```python
+class AlertRuleUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    expected_version: int = Field(ge=1)
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    operator: AlertOperator | None = None
+    threshold: float | None = None
+    aggregation: AlertAggregation | None = None
+    window: AlertDuration | None = None
+    duration: AlertDuration | None = None
+    severity: AlertSeverity | None = None
+    channels: tuple[AlertChannel, ...] | None = None
+    cooldown_seconds: int | None = Field(default=None, ge=60, le=86_400)
+    enabled: bool | None = None
+```
+
+`AlertRuleService.create` and `.replace` call `DomainRepository.get_pond` and, when applicable, `get_device`; any missing or pond-mismatched target raises `NotFoundError`.
+
+- [x] **Step 4: Run focused list/create/PATCH tests and verify GREEN**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/api/test_alert_rules.py -q`
+
+Expected: list/create/PATCH tests pass.
+
+- [x] **Step 5: Write failing replacement header and replay tests**
+
+```python
+def test_replace_requires_valid_idempotency_key() -> None:
+    assert client.post(replace_path, json=replace_payload, headers=headers).status_code == 422
+
+
+def test_replace_returns_old_and_new_rule_and_replays() -> None:
+    first = client.post(replace_path, json=replace_payload, headers={**headers, "Idempotency-Key": "replace-123"})
+    replay = client.post(replace_path, json=replace_payload, headers={**headers, "Idempotency-Key": "replace-123"})
+    assert first.status_code == 201
+    assert replay.json() == first.json()
+```
+
+- [x] **Step 6: Implement replace route and audit request context**
+
+The router derives `AuditContext` from the authenticated principal, `request.client.host`, and `User-Agent`. It hashes canonical path/body identity through the service and forwards the required idempotency key to the repository.
+
+- [x] **Step 7: Run API/full tests and commit**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/api/test_alert_rules.py -q`
+
+Expected: all Task 3 tests pass.
+
+Run: `git add src/limnopulse_api/services/alert_rules.py src/limnopulse_api/api/v1/schemas/alert_rules.py src/limnopulse_api/api/v1/routers/alert_rules.py src/limnopulse_api/api/dependencies.py src/limnopulse_api/api/router.py src/limnopulse_api/main.py tests/api/test_alert_rules.py && git commit -m "feat: expose alert rule API"`
+
+### Task 4: DynamoDB TTL infrastructure
+
+**Files:**
+- Modify: `infra/opentofu/dynamodb.tf`
+- Modify: `scripts/dev/init_dynamodb.py`
+- Modify: `tests/unit/test_opentofu_infra.py`
+- Create: `tests/unit/test_init_dynamodb.py`
+
+**Interfaces:**
+- Produces: both cloud tables and local tables with DynamoDB TTL enabled on numeric `expires_at` values.
+
+- [x] **Step 1: Write failing infrastructure tests**
+
+```python
+def test_cloud_domain_and_audit_tables_enable_expires_at_ttl() -> None:
+    dynamodb = _read("dynamodb.tf")
+    assert dynamodb.count('attribute_name = "expires_at"') == 2
+    assert dynamodb.count("enabled        = true") >= 2
+
+
+def test_existing_local_table_has_ttl_enabled() -> None:
+    ensure_table(client, "LimnopulseDomain")
+    assert client.update_time_to_live_calls == [{"TableName": "LimnopulseDomain", "TimeToLiveSpecification": {"Enabled": True, "AttributeName": "expires_at"}}]
+```
+
+- [x] **Step 2: Run infrastructure tests and verify RED**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_opentofu_infra.py tests/unit/test_init_dynamodb.py -q`
+
+Expected: TTL assertions fail.
+
+- [x] **Step 3: Enable TTL in OpenTofu and local initialization**
+
+```hcl
+ttl {
+  attribute_name = "expires_at"
+  enabled        = true
+}
+```
+
+`ensure_table` calls `update_time_to_live` for both newly created and pre-existing tables, and treats an already-enabled TTL as success.
+
+- [x] **Step 4: Run infrastructure tests and verify GREEN, then commit**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest tests/unit/test_opentofu_infra.py tests/unit/test_init_dynamodb.py -q`
+
+Expected: all Task 4 tests pass.
+
+Run: `git add infra/opentofu/dynamodb.tf scripts/dev/init_dynamodb.py tests/unit/test_opentofu_infra.py tests/unit/test_init_dynamodb.py && git commit -m "feat: enable DynamoDB record expiry"`
+
+### Task 5: Architecture normalization and final verification
+
+**Files:**
+- Create: `docs/architecture.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Documents the canonical Limnopulse naming and the boundary between delivered Phase 3A and target Phase 3B/3C behavior.
+
+- [x] **Step 1: Normalize architecture documentation**
+
+Document `LimnopulseDomain`, `LimnopulseAudit`, `limnopulse/v1/devices/...`, `limnopulse_raw`, current implemented components, Phase 3A Alert Rules, Phase 3B evaluator/cooldown, and Phase 3C dispatch/providers. Remove AquaFarm names while retaining the predecessor context only as migration history.
+
+- [x] **Step 2: Update README usage examples**
+
+Add the Alert Rules endpoint list, compact duration format, role requirements, replacement idempotency behavior, and local DynamoDB initialization command.
+
+- [x] **Step 3: Run complete verification**
+
+Run: `uv run --extra dev --python 3.12 python -m pytest -q`
+
+Expected: all tests pass with no failures.
+
+Run: `uv run --extra dev --python 3.12 python -m compileall -q src tests scripts`
+
+Expected: exit code 0.
+
+Run: `tofu -chdir=infra/opentofu fmt -check`
+
+Expected: exit code 0.
+
+Run: `git diff --check origin/main...HEAD`
+
+Expected: exit code 0.
+
+- [x] **Step 4: Review the diff and commit documentation**
+
+Run: `git add README.md docs/architecture.md docs/superpowers/specs/2026-07-15-limnopulse-phase-3a-alert-rules-design.md docs/superpowers/plans/2026-07-15-limnopulse-phase-3a-alert-rules.md && git commit -m "docs: define alert rule milestone"`
+
+Expected: the branch contains only Phase 3A code, tests, infrastructure, and documentation plus `.gitignore` worktree protection.

--- a/docs/superpowers/specs/2026-07-15-limnopulse-phase-3a-alert-rules-design.md
+++ b/docs/superpowers/specs/2026-07-15-limnopulse-phase-3a-alert-rules-design.md
@@ -1,0 +1,106 @@
+# Limnopulse Phase 3A Alert Rules Design
+
+**Date:** 2026-07-15
+**Status:** Approved for implementation
+
+## Scope
+
+Phase 3A adds tenant-scoped alert-rule configuration to the FastAPI/DynamoDB domain. It does not evaluate telemetry, create alert events, apply Redis cooldowns, dispatch notifications, or integrate notification providers. Those responsibilities remain in Phase 3B and Phase 3C.
+
+## API contract
+
+The API exposes:
+
+- `GET /v1/tenants/{tenant_id}/alert-rules` for owner, admin, member, and viewer roles.
+- `POST /v1/tenants/{tenant_id}/alert-rules` for owner and admin roles, returning `201`.
+- `PATCH /v1/tenants/{tenant_id}/alert-rules/{rule_id}` for owner and admin roles.
+- `POST /v1/tenants/{tenant_id}/alert-rules/{rule_id}/replace` for owner and admin roles, returning `201` and requiring an `Idempotency-Key` header of 8 to 128 characters.
+
+There is no individual GET, DELETE, AlertEvent endpoint, or channel integration in Phase 3A.
+
+All request models reject unknown fields. PATCH requires `expected_version` and at least one mutable field. Identity fields supplied to PATCH are rejected with `422`.
+
+## AlertRule model
+
+Semantic identity is immutable after creation:
+
+- `tenant_id`
+- `pond_id`
+- optional `device_id`
+- `metric`
+
+Mutable fields are:
+
+- `name`
+- `operator`
+- `threshold`
+- `aggregation`
+- `window`
+- `duration`
+- `severity`
+- `channels`
+- `cooldown_seconds`
+- `enabled`
+
+Rules use server-generated IDs in the form `rule_<uuid hex>`. The supported values are:
+
+- metrics: `temp_c`, `ph`, `do_mg_l`, `turbidity_ntu`, `salinity_ppt`, `battery_v`, `rssi`
+- operators: `<`, `<=`, `>`, `>=`
+- aggregations: `min`, `max`, `mean`, `last`
+- severities: `warning`, `critical`
+- channels: `email`, `telegram`
+
+`window` and `duration` are compact duration strings such as `60s`, `5m`, or `24h`, each bounded to 60 seconds through 24 hours. `cooldown_seconds` is bounded to 60 through 86,400. At least one unique notification channel is required.
+
+Every target pond must exist in the tenant. When `device_id` is present, that device must exist in the same tenant and pond. Missing and mismatched targets return `404` without revealing cross-tenant resource existence.
+
+## Update and replacement semantics
+
+PATCH uses optimistic concurrency. A matching `expected_version` increments `version`; a stale version returns `409`.
+
+Changing semantic identity requires replacement. Replacement atomically:
+
+1. disables the old rule;
+2. sets its status to `replaced`;
+3. increments its version;
+4. sets `replaced_by_rule_id`;
+5. creates a version-1 replacement with `replaces_rule_id`;
+6. writes an audit record;
+7. persists the idempotency result.
+
+The response is `{ "replaced": <old rule>, "replacement": <new rule> }`.
+
+The same idempotency key and request payload replays the stored result for 24 hours. Reusing the same key with a different request payload returns `409`. Expired records may remain physically present because DynamoDB TTL deletion is eventual; application conditions therefore treat `expires_at <= now` as reusable.
+
+## Persistence
+
+Alert rules live in `LimnopulseDomain`:
+
+```text
+PK = TENANT#<tenant_id>
+SK = ALERT_RULE#<rule_id>
+```
+
+List operations use DynamoDB `Query` with the `ALERT_RULE#` sort-key prefix and never use `Scan`.
+
+Replacement idempotency records also live in `LimnopulseDomain` under a SHA-256-derived sort key. They contain only the request hash, response snapshots, timestamps, and numeric `expires_at`; raw idempotency keys and authentication material are not persisted.
+
+Audit records live in `LimnopulseAudit`:
+
+```text
+PK = TENANT#<tenant_id>#MONTH#YYYY-MM
+SK = <timestamp>#<event_id>
+```
+
+Each mutation transaction spans the domain and audit tables. Audit records contain actor/action/resource metadata, SHA-256 hashes of before and after state, request IP, user agent, creation time, and numeric `expires_at`. They do not contain JWTs, credentials, or request payloads. Audit TTL is 90 days.
+
+TTL on `expires_at` is enabled for both DynamoDB tables in OpenTofu and local initialization.
+
+## Module boundaries
+
+Alert-rule persistence is exposed through a new `AlertRuleRepository` protocol and implemented by `DynamoAlertRuleRepository`. `DomainRepository` remains focused on tenants, memberships, ponds, and devices. `AlertRuleService` owns target validation and ID generation; the adapter owns atomic storage, version conditions, audit serialization, and idempotent replay.
+
+## Phase handoff
+
+- Phase 3B: Go evaluator, InfluxDB windows, Redis cooldown/deduplication, and AlertEvent creation.
+- Phase 3C: SQS dispatcher, SES, Telegram, retries, and delivery records.

--- a/infra/opentofu/dynamodb.tf
+++ b/infra/opentofu/dynamodb.tf
@@ -14,6 +14,11 @@ resource "aws_dynamodb_table" "domain" {
     type = "S"
   }
 
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
   point_in_time_recovery {
     enabled = true
   }
@@ -37,6 +42,11 @@ resource "aws_dynamodb_table" "audit" {
   attribute {
     name = "SK"
     type = "S"
+  }
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
   }
 
   point_in_time_recovery {

--- a/scripts/dev/init_dynamodb.py
+++ b/scripts/dev/init_dynamodb.py
@@ -9,22 +9,39 @@ def ensure_table(client: boto3.client, table_name: str) -> None:
     existing_tables = set(client.list_tables()["TableNames"])
     if table_name in existing_tables:
         print(f"Table {table_name} already exists")
-        return
+    else:
+        client.create_table(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        client.get_waiter("table_exists").wait(TableName=table_name)
+        print(f"Created table {table_name}")
 
-    client.create_table(
+    ensure_ttl(client, table_name)
+
+
+def ensure_ttl(client: boto3.client, table_name: str) -> None:
+    response = client.describe_time_to_live(TableName=table_name)
+    status = response.get("TimeToLiveDescription", {}).get("TimeToLiveStatus")
+    if status in {"ENABLED", "ENABLING"}:
+        print(f"TTL already enabled for {table_name}")
+        return
+    client.update_time_to_live(
         TableName=table_name,
-        KeySchema=[
-            {"AttributeName": "PK", "KeyType": "HASH"},
-            {"AttributeName": "SK", "KeyType": "RANGE"},
-        ],
-        AttributeDefinitions=[
-            {"AttributeName": "PK", "AttributeType": "S"},
-            {"AttributeName": "SK", "AttributeType": "S"},
-        ],
-        BillingMode="PAY_PER_REQUEST",
+        TimeToLiveSpecification={
+            "Enabled": True,
+            "AttributeName": "expires_at",
+        },
     )
-    client.get_waiter("table_exists").wait(TableName=table_name)
-    print(f"Created table {table_name}")
+    print(f"Enabled TTL for {table_name}")
 
 
 def main() -> None:

--- a/src/limnopulse_api/adapters/alert_rules.py
+++ b/src/limnopulse_api/adapters/alert_rules.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from hashlib import sha256
+import json
+from typing import Any
+from uuid import uuid4
+
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from pydantic import BaseModel
+
+from limnopulse_api.core.errors import ConflictError, NotFoundError
+from limnopulse_api.domain.alerts import (
+    AlertRule,
+    AlertRuleReplacement,
+    AlertRuleUpdates,
+    AuditContext,
+)
+
+
+AUDIT_RETENTION = timedelta(days=90)
+IDEMPOTENCY_RETENTION = timedelta(hours=24)
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+class DynamoAlertRuleRepository:
+    def __init__(
+        self,
+        domain_table_name: str,
+        audit_table_name: str,
+        client: Any,
+        *,
+        clock: Callable[[], datetime] = utc_now,
+    ) -> None:
+        self.domain_table_name = domain_table_name
+        self.audit_table_name = audit_table_name
+        self.client = client
+        self.clock = clock
+        self._serializer = TypeSerializer()
+        self._deserializer = TypeDeserializer()
+
+    async def list_rules(self, tenant_id: str) -> list[AlertRule]:
+        items: list[dict[str, Any]] = []
+        last_evaluated_key: dict[str, Any] | None = None
+        while True:
+            request: dict[str, Any] = {
+                "TableName": self.domain_table_name,
+                "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk_prefix)",
+                "ExpressionAttributeValues": self._serialize_values(
+                    {
+                        ":pk": f"TENANT#{tenant_id}",
+                        ":sk_prefix": "ALERT_RULE#",
+                    }
+                ),
+            }
+            if last_evaluated_key is not None:
+                request["ExclusiveStartKey"] = last_evaluated_key
+            response = self.client.query(**request)
+            items.extend(self._response_items(response))
+            last_evaluated_key = response.get("LastEvaluatedKey")
+            if last_evaluated_key is None:
+                break
+        return [self._rule_from_item(item) for item in items]
+
+    async def create_rule(self, rule: AlertRule, audit: AuditContext) -> AlertRule:
+        now = self.clock()
+        rule_item = self._rule_to_item(rule)
+        audit_item = self._audit_item(
+            tenant_id=rule.tenant_id,
+            action="alert_rule.created",
+            resource_id=rule.rule_id,
+            before=None,
+            after=rule,
+            context=audit,
+            now=now,
+        )
+        self._transact(
+            [
+                self._conditioned_put(self.domain_table_name, rule_item),
+                self._conditioned_put(self.audit_table_name, audit_item),
+            ]
+        )
+        return rule
+
+    async def update_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        updates: AlertRuleUpdates,
+        audit: AuditContext,
+    ) -> AlertRule:
+        existing = self._get_rule(tenant_id, rule_id)
+        if existing is None:
+            raise NotFoundError(f"Alert rule {rule_id} not found")
+
+        now = self.clock()
+        updated = AlertRule.model_validate(
+            {
+                **existing.model_dump(mode="python"),
+                **dict(updates),
+                "updated_at": now,
+                "version": expected_version + 1,
+            }
+        )
+        audit_item = self._audit_item(
+            tenant_id=tenant_id,
+            action="alert_rule.updated",
+            resource_id=rule_id,
+            before=existing,
+            after=updated,
+            context=audit,
+            now=now,
+        )
+        self._transact(
+            [
+                self._conditioned_rule_update(
+                    tenant_id=tenant_id,
+                    rule_id=rule_id,
+                    expected_version=expected_version,
+                    updates={
+                        **dict(updates),
+                        "updated_at": now.isoformat(),
+                        "version": expected_version + 1,
+                    },
+                ),
+                self._conditioned_put(self.audit_table_name, audit_item),
+            ]
+        )
+        return updated
+
+    async def replace_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        replacement: AlertRule,
+        idempotency_key: str,
+        request_hash: str,
+        audit: AuditContext,
+    ) -> AlertRuleReplacement:
+        now = self.clock()
+        idempotency_key_fields = self._idempotency_key(tenant_id, idempotency_key)
+        stored = self._get_item(self.domain_table_name, idempotency_key_fields)
+        replay = self._replay_idempotency(stored, request_hash, now)
+        if replay is not None:
+            return replay
+
+        existing = self._get_rule(tenant_id, rule_id)
+        if existing is None:
+            raise NotFoundError(f"Alert rule {rule_id} not found")
+
+        replaced = AlertRule.model_validate(
+            {
+                **existing.model_dump(mode="python"),
+                "enabled": False,
+                "status": "replaced",
+                "replaced_by_rule_id": replacement.rule_id,
+                "updated_at": now,
+                "version": expected_version + 1,
+            }
+        )
+        replacement = AlertRule.model_validate(
+            {
+                **replacement.model_dump(mode="python"),
+                "tenant_id": tenant_id,
+                "replaces_rule_id": rule_id,
+                "replaced_by_rule_id": None,
+                "status": "active",
+                "version": 1,
+            }
+        )
+        result = AlertRuleReplacement(replaced=replaced, replacement=replacement)
+        audit_item = self._audit_item(
+            tenant_id=tenant_id,
+            action="alert_rule.replaced",
+            resource_id=rule_id,
+            before=existing,
+            after=result,
+            context=audit,
+            now=now,
+        )
+        idempotency_item = {
+            **idempotency_key_fields,
+            "entity_type": "alert_rule_replace_idempotency",
+            "request_hash": request_hash,
+            "replaced": replaced.model_dump(mode="json"),
+            "replacement": replacement.model_dump(mode="json"),
+            "created_at": now.isoformat(),
+            "expires_at": int((now + IDEMPOTENCY_RETENTION).timestamp()),
+        }
+        idempotency_put = {
+            "Put": {
+                "TableName": self.domain_table_name,
+                "Item": self._serialize_item(idempotency_item),
+                "ConditionExpression": "attribute_not_exists(PK) OR #expires_at <= :now",
+                "ExpressionAttributeNames": {"#expires_at": "expires_at"},
+                "ExpressionAttributeValues": self._serialize_values(
+                    {":now": int(now.timestamp())}
+                ),
+            }
+        }
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    self._conditioned_rule_update(
+                        tenant_id=tenant_id,
+                        rule_id=rule_id,
+                        expected_version=expected_version,
+                        updates={
+                            "enabled": False,
+                            "status": "replaced",
+                            "replaced_by_rule_id": replacement.rule_id,
+                            "updated_at": now.isoformat(),
+                            "version": expected_version + 1,
+                        },
+                    ),
+                    self._conditioned_put(
+                        self.domain_table_name,
+                        self._rule_to_item(replacement),
+                    ),
+                    self._conditioned_put(self.audit_table_name, audit_item),
+                    idempotency_put,
+                ],
+                ClientRequestToken=self._client_request_token(
+                    tenant_id,
+                    idempotency_key,
+                    request_hash,
+                ),
+            )
+        except Exception as exc:
+            replay = self._replay_idempotency(
+                self._get_item(self.domain_table_name, idempotency_key_fields),
+                request_hash,
+                now,
+            )
+            if replay is not None:
+                return replay
+            self._raise_if_conflict(exc)
+            raise
+        return result
+
+    def _get_rule(self, tenant_id: str, rule_id: str) -> AlertRule | None:
+        item = self._get_item(
+            self.domain_table_name,
+            self._rule_key(tenant_id, rule_id),
+        )
+        if item is None:
+            return None
+        return self._rule_from_item(item)
+
+    def _get_item(
+        self,
+        table_name: str,
+        key: Mapping[str, str],
+    ) -> dict[str, Any] | None:
+        response = self.client.get_item(
+            TableName=table_name,
+            Key=self._serialize_item(dict(key)),
+        )
+        item = response.get("Item")
+        if item is None:
+            return None
+        return self._deserialize_item(item)
+
+    def _conditioned_put(
+        self,
+        table_name: str,
+        item: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "Put": {
+                "TableName": table_name,
+                "Item": self._serialize_item(item),
+                "ConditionExpression": "attribute_not_exists(PK) AND attribute_not_exists(SK)",
+            }
+        }
+
+    def _conditioned_rule_update(
+        self,
+        *,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        updates: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        names = {
+            "#version": "version",
+            "#status": "status",
+        }
+        values: dict[str, Any] = {
+            ":expected_version": expected_version,
+            ":active": "active",
+        }
+        assignments: list[str] = []
+        for index, (field_name, field_value) in enumerate(updates.items()):
+            name_token = f"#field_{index}"
+            value_token = f":value_{index}"
+            names[name_token] = field_name
+            values[value_token] = field_value
+            assignments.append(f"{name_token} = {value_token}")
+        return {
+            "Update": {
+                "TableName": self.domain_table_name,
+                "Key": self._serialize_item(self._rule_key(tenant_id, rule_id)),
+                "UpdateExpression": "SET " + ", ".join(assignments),
+                "ConditionExpression": (
+                    "attribute_exists(PK) AND attribute_exists(SK) "
+                    "AND #version = :expected_version AND #status = :active"
+                ),
+                "ExpressionAttributeNames": names,
+                "ExpressionAttributeValues": self._serialize_values(values),
+            }
+        }
+
+    def _transact(self, operations: list[dict[str, Any]]) -> None:
+        try:
+            self.client.transact_write_items(TransactItems=operations)
+        except Exception as exc:
+            self._raise_if_conflict(exc)
+            raise
+
+    def _raise_if_conflict(self, exc: Exception) -> None:
+        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
+        if error_code in {
+            "ConditionalCheckFailedException",
+            "TransactionCanceledException",
+            "IdempotentParameterMismatchException",
+        }:
+            raise ConflictError(str(exc)) from exc
+
+    def _audit_item(
+        self,
+        *,
+        tenant_id: str,
+        action: str,
+        resource_id: str,
+        before: Any,
+        after: Any,
+        context: AuditContext,
+        now: datetime,
+    ) -> dict[str, Any]:
+        event_id = f"audit_{uuid4().hex}"
+        return {
+            "PK": f"TENANT#{tenant_id}#MONTH#{now:%Y-%m}",
+            "SK": f"{now.isoformat()}#{event_id}",
+            "entity_type": "audit_event",
+            "event_id": event_id,
+            "tenant_id": tenant_id,
+            "actor_type": "user",
+            "actor_id": context.actor_id,
+            "action": action,
+            "resource_type": "alert_rule",
+            "resource_id": resource_id,
+            "before_hash": self._hash_state(before),
+            "after_hash": self._hash_state(after),
+            "ip": context.ip,
+            "user_agent": context.user_agent,
+            "created_at": now.isoformat(),
+            "expires_at": int((now + AUDIT_RETENTION).timestamp()),
+        }
+
+    def _replay_idempotency(
+        self,
+        item: dict[str, Any] | None,
+        request_hash: str,
+        now: datetime,
+    ) -> AlertRuleReplacement | None:
+        if item is None or int(item.get("expires_at", 0)) <= int(now.timestamp()):
+            return None
+        if item.get("request_hash") != request_hash:
+            raise ConflictError("idempotency key already used with another request")
+        return AlertRuleReplacement(
+            replaced=AlertRule.model_validate(item["replaced"]),
+            replacement=AlertRule.model_validate(item["replacement"]),
+        )
+
+    def _rule_key(self, tenant_id: str, rule_id: str) -> dict[str, str]:
+        return {
+            "PK": f"TENANT#{tenant_id}",
+            "SK": f"ALERT_RULE#{rule_id}",
+        }
+
+    def _idempotency_key(self, tenant_id: str, idempotency_key: str) -> dict[str, str]:
+        digest = sha256(f"{tenant_id}\0{idempotency_key}".encode()).hexdigest()
+        return {
+            "PK": f"TENANT#{tenant_id}",
+            "SK": f"IDEMPOTENCY#ALERT_RULE_REPLACE#{digest}",
+        }
+
+    def _client_request_token(
+        self,
+        tenant_id: str,
+        idempotency_key: str,
+        request_hash: str,
+    ) -> str:
+        value = f"{tenant_id}\0{idempotency_key}\0{request_hash}".encode()
+        return sha256(value).hexdigest()[:36]
+
+    def _rule_to_item(self, rule: AlertRule) -> dict[str, Any]:
+        return {
+            **self._rule_key(rule.tenant_id, rule.rule_id),
+            "entity_type": "alert_rule",
+            **rule.model_dump(mode="json"),
+        }
+
+    def _rule_from_item(self, item: Mapping[str, Any]) -> AlertRule:
+        values = {
+            key: value
+            for key, value in item.items()
+            if key not in {"PK", "SK", "entity_type"}
+        }
+        return AlertRule.model_validate(values)
+
+    def _response_items(self, response: Mapping[str, Any]) -> list[dict[str, Any]]:
+        return [self._deserialize_item(item) for item in response.get("Items", [])]
+
+    def _hash_state(self, value: Any) -> str:
+        encoded = json.dumps(
+            self._jsonable(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+        return sha256(encoded).hexdigest()
+
+    def _jsonable(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.model_dump(mode="json")
+        return value
+
+    def _serialize_item(self, item: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            key: self._serializer.serialize(self._normalize_for_dynamodb(value))
+            for key, value in item.items()
+        }
+
+    def _serialize_values(self, values: Mapping[str, Any]) -> dict[str, Any]:
+        return self._serialize_item(values)
+
+    def _normalize_for_dynamodb(self, value: Any) -> Any:
+        if isinstance(value, float):
+            return Decimal(str(value))
+        if isinstance(value, Mapping):
+            return {
+                key: self._normalize_for_dynamodb(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [self._normalize_for_dynamodb(item) for item in value]
+        return value
+
+    def _deserialize_item(self, item: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            key: self._normalize_from_dynamodb(self._deserializer.deserialize(value))
+            for key, value in item.items()
+        }
+
+    def _normalize_from_dynamodb(self, value: Any) -> Any:
+        if isinstance(value, Decimal):
+            if value % 1 == 0:
+                return int(value)
+            return float(value)
+        if isinstance(value, list):
+            return [self._normalize_from_dynamodb(item) for item in value]
+        if isinstance(value, Mapping):
+            return {
+                key: self._normalize_from_dynamodb(item)
+                for key, item in value.items()
+            }
+        return value

--- a/src/limnopulse_api/adapters/alert_rules.py
+++ b/src/limnopulse_api/adapters/alert_rules.py
@@ -146,8 +146,11 @@ class DynamoAlertRuleRepository:
     ) -> AlertRuleReplacement:
         now = self.clock()
         idempotency_key_fields = self._idempotency_key(tenant_id, idempotency_key)
-        stored = self._get_item(self.domain_table_name, idempotency_key_fields)
-        replay = self._replay_idempotency(stored, request_hash, now)
+        replay = await self.get_replacement_replay(
+            tenant_id,
+            idempotency_key,
+            request_hash,
+        )
         if replay is not None:
             return replay
 
@@ -200,9 +203,7 @@ class DynamoAlertRuleRepository:
                 "Item": self._serialize_item(idempotency_item),
                 "ConditionExpression": "attribute_not_exists(PK) OR #expires_at <= :now",
                 "ExpressionAttributeNames": {"#expires_at": "expires_at"},
-                "ExpressionAttributeValues": self._serialize_values(
-                    {":now": int(now.timestamp())}
-                ),
+                "ExpressionAttributeValues": self._serialize_values({":now": int(now.timestamp())}),
             }
         }
         try:
@@ -244,6 +245,18 @@ class DynamoAlertRuleRepository:
             self._raise_if_conflict(exc)
             raise
         return result
+
+    async def get_replacement_replay(
+        self,
+        tenant_id: str,
+        idempotency_key: str,
+        request_hash: str,
+    ) -> AlertRuleReplacement | None:
+        item = self._get_item(
+            self.domain_table_name,
+            self._idempotency_key(tenant_id, idempotency_key),
+        )
+        return self._replay_idempotency(item, request_hash, self.clock())
 
     def _get_rule(self, tenant_id: str, rule_id: str) -> AlertRule | None:
         item = self._get_item(
@@ -326,12 +339,20 @@ class DynamoAlertRuleRepository:
             raise
 
     def _raise_if_conflict(self, exc: Exception) -> None:
-        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
+        response = getattr(exc, "response", {})
+        error_code = response.get("Error", {}).get("Code")
         if error_code in {
             "ConditionalCheckFailedException",
-            "TransactionCanceledException",
             "IdempotentParameterMismatchException",
         }:
+            raise ConflictError(str(exc)) from exc
+        if error_code != "TransactionCanceledException":
+            return
+        reasons = response.get("CancellationReasons")
+        if reasons is None or any(
+            reason.get("Code") in {"ConditionalCheckFailed", "TransactionConflict"}
+            for reason in reasons
+        ):
             raise ConflictError(str(exc)) from exc
 
     def _audit_item(
@@ -411,9 +432,7 @@ class DynamoAlertRuleRepository:
 
     def _rule_from_item(self, item: Mapping[str, Any]) -> AlertRule:
         values = {
-            key: value
-            for key, value in item.items()
-            if key not in {"PK", "SK", "entity_type"}
+            key: value for key, value in item.items() if key not in {"PK", "SK", "entity_type"}
         }
         return AlertRule.model_validate(values)
 
@@ -447,10 +466,7 @@ class DynamoAlertRuleRepository:
         if isinstance(value, float):
             return Decimal(str(value))
         if isinstance(value, Mapping):
-            return {
-                key: self._normalize_for_dynamodb(item)
-                for key, item in value.items()
-            }
+            return {key: self._normalize_for_dynamodb(item) for key, item in value.items()}
         if isinstance(value, (list, tuple)):
             return [self._normalize_for_dynamodb(item) for item in value]
         return value
@@ -469,8 +485,5 @@ class DynamoAlertRuleRepository:
         if isinstance(value, list):
             return [self._normalize_from_dynamodb(item) for item in value]
         if isinstance(value, Mapping):
-            return {
-                key: self._normalize_from_dynamodb(item)
-                for key, item in value.items()
-            }
+            return {key: self._normalize_from_dynamodb(item) for key, item in value.items()}
         return value

--- a/src/limnopulse_api/api/dependencies.py
+++ b/src/limnopulse_api/api/dependencies.py
@@ -9,6 +9,7 @@ from limnopulse_api.core.errors import AuthError
 from limnopulse_api.domain.entities import TenantAccess
 from limnopulse_api.domain.roles import READ_ROLES, TenantRole
 from limnopulse_api.repositories.domain import DomainRepository
+from limnopulse_api.repositories.alerts import AlertRuleRepository
 from limnopulse_api.repositories.telemetry import TelemetryRepository
 from limnopulse_api.services.memberships import MembershipService
 
@@ -48,14 +49,14 @@ def get_membership_service(request: Request) -> MembershipService:
     return _get_state_dependency(request, "membership_service")
 
 
-def get_telemetry_repository(request: Request) -> TelemetryRepository:
-    return _get_state_dependency(request, "telemetry_repository")
+def get_alert_rule_repository(request: Request) -> AlertRuleRepository:
+    return _get_state_dependency(request, "alert_rule_repository")
 
 
 DomainRepositoryDep = Annotated[DomainRepository, Depends(get_domain_repository)]
+AlertRuleRepositoryDep = Annotated[AlertRuleRepository, Depends(get_alert_rule_repository)]
 TelemetryRepositoryDep = Annotated[TelemetryRepository, Depends(get_telemetry_repository)]
 MembershipServiceDep = Annotated[MembershipService, Depends(get_membership_service)]
-TelemetryRepositoryDep = Annotated[TelemetryRepository, Depends(get_telemetry_repository)]
 
 
 async def require_tenant_access(

--- a/src/limnopulse_api/api/router.py
+++ b/src/limnopulse_api/api/router.py
@@ -1,6 +1,14 @@
 from fastapi import APIRouter
 
-from limnopulse_api.api.v1.routers import alert_rules, devices, health, me, ponds, telemetry, tenants
+from limnopulse_api.api.v1.routers import (
+    alert_rules,
+    devices,
+    health,
+    me,
+    ponds,
+    telemetry,
+    tenants,
+)
 
 api_router = APIRouter()
 api_router.include_router(health.router)

--- a/src/limnopulse_api/api/router.py
+++ b/src/limnopulse_api/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from limnopulse_api.api.v1.routers import devices, health, me, ponds, telemetry, tenants
+from limnopulse_api.api.v1.routers import alert_rules, devices, health, me, ponds, telemetry, tenants
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -9,3 +9,4 @@ api_router.include_router(tenants.router, prefix="/v1")
 api_router.include_router(ponds.router, prefix="/v1")
 api_router.include_router(telemetry.router, prefix="/v1")
 api_router.include_router(devices.router, prefix="/v1")
+api_router.include_router(alert_rules.router, prefix="/v1")

--- a/src/limnopulse_api/api/v1/routers/alert_rules.py
+++ b/src/limnopulse_api/api/v1/routers/alert_rules.py
@@ -1,0 +1,173 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+
+from limnopulse_api.api.dependencies import (
+    AlertRuleRepositoryDep,
+    DomainRepositoryDep,
+    require_tenant_role,
+)
+from limnopulse_api.api.v1.schemas.alert_rules import (
+    AlertRuleCreate,
+    AlertRuleListResponse,
+    AlertRuleReplace,
+    AlertRuleReplacementResponse,
+    AlertRuleResponse,
+    AlertRuleUpdate,
+)
+from limnopulse_api.api.v1.schemas.common import ErrorResponse
+from limnopulse_api.core.errors import ConflictError, NotFoundError
+from limnopulse_api.domain.alerts import AlertRule, AuditContext
+from limnopulse_api.domain.entities import TenantAccess
+from limnopulse_api.domain.roles import READ_ROLES, WRITE_ROLES
+from limnopulse_api.services.alert_rules import AlertRuleService
+
+
+router = APIRouter(prefix="/tenants/{tenant_id}/alert-rules", tags=["alert-rules"])
+
+
+def _service(
+    repository: AlertRuleRepositoryDep,
+    domain_repository: DomainRepositoryDep,
+) -> AlertRuleService:
+    return AlertRuleService(repository, domain_repository)
+
+
+def _response(rule: AlertRule) -> AlertRuleResponse:
+    return AlertRuleResponse.model_validate(rule.model_dump(mode="json"))
+
+
+def _audit_context(request: Request, access: TenantAccess) -> AuditContext:
+    return AuditContext(
+        actor_id=access.principal.cognito_sub,
+        ip=request.client.host if request.client is not None else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+
+@router.get(
+    "",
+    response_model=AlertRuleListResponse,
+    responses={403: {"model": ErrorResponse}, 503: {"model": ErrorResponse}},
+)
+async def list_alert_rules(
+    tenant_id: str,
+    repository: AlertRuleRepositoryDep,
+    domain_repository: DomainRepositoryDep,
+    _access: TenantAccess = Depends(require_tenant_role(*tuple(READ_ROLES))),
+) -> AlertRuleListResponse:
+    rules = await _service(repository, domain_repository).list(tenant_id)
+    return AlertRuleListResponse(items=[_response(rule) for rule in rules])
+
+
+@router.post(
+    "",
+    response_model=AlertRuleResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+)
+async def create_alert_rule(
+    tenant_id: str,
+    payload: AlertRuleCreate,
+    request: Request,
+    repository: AlertRuleRepositoryDep,
+    domain_repository: DomainRepositoryDep,
+    access: TenantAccess = Depends(require_tenant_role(*tuple(WRITE_ROLES))),
+) -> AlertRuleResponse:
+    try:
+        rule = await _service(repository, domain_repository).create(
+            tenant_id,
+            payload.model_dump(mode="python"),
+            _audit_context(request, access),
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc) or "not found") from exc
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc) or "conflict") from exc
+    return _response(rule)
+
+
+@router.patch(
+    "/{rule_id}",
+    response_model=AlertRuleResponse,
+    responses={
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+)
+async def update_alert_rule(
+    tenant_id: str,
+    rule_id: str,
+    payload: AlertRuleUpdate,
+    request: Request,
+    repository: AlertRuleRepositoryDep,
+    domain_repository: DomainRepositoryDep,
+    access: TenantAccess = Depends(require_tenant_role(*tuple(WRITE_ROLES))),
+) -> AlertRuleResponse:
+    try:
+        rule = await _service(repository, domain_repository).update(
+            tenant_id,
+            rule_id,
+            payload.expected_version,
+            payload.updates(),
+            _audit_context(request, access),
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc) or "not found") from exc
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc) or "conflict") from exc
+    return _response(rule)
+
+
+@router.post(
+    "/{rule_id}/replace",
+    response_model=AlertRuleReplacementResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+)
+async def replace_alert_rule(
+    tenant_id: str,
+    rule_id: str,
+    payload: AlertRuleReplace,
+    request: Request,
+    repository: AlertRuleRepositoryDep,
+    domain_repository: DomainRepositoryDep,
+    idempotency_key: Annotated[
+        str,
+        Header(alias="Idempotency-Key", min_length=8, max_length=128),
+    ],
+    access: TenantAccess = Depends(require_tenant_role(*tuple(WRITE_ROLES))),
+) -> AlertRuleReplacementResponse:
+    definition = payload.model_dump(
+        mode="python",
+        exclude={"expected_version"},
+    )
+    try:
+        result = await _service(repository, domain_repository).replace(
+            tenant_id,
+            rule_id,
+            payload.expected_version,
+            definition,
+            idempotency_key,
+            _audit_context(request, access),
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc) or "not found") from exc
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc) or "conflict") from exc
+    return AlertRuleReplacementResponse(
+        replaced=_response(result.replaced),
+        replacement=_response(result.replacement),
+    )

--- a/src/limnopulse_api/api/v1/schemas/alert_rules.py
+++ b/src/limnopulse_api/api/v1/schemas/alert_rules.py
@@ -1,0 +1,120 @@
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from limnopulse_api.api.v1.schemas.common import VersionedResponse
+from limnopulse_api.domain.alerts import (
+    AlertAggregation,
+    AlertChannel,
+    AlertDuration,
+    AlertMetric,
+    AlertOperator,
+    AlertSeverity,
+)
+
+
+class AlertRuleDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pond_id: str
+    device_id: str | None = None
+    metric: AlertMetric
+    name: str = Field(min_length=1, max_length=120)
+    operator: AlertOperator
+    threshold: float = Field(allow_inf_nan=False)
+    aggregation: AlertAggregation
+    window: AlertDuration
+    duration: AlertDuration
+    severity: AlertSeverity
+    channels: tuple[AlertChannel, ...] = Field(min_length=1)
+    cooldown_seconds: int = Field(ge=60, le=86_400)
+    enabled: bool
+
+    @field_validator("channels")
+    @classmethod
+    def channels_must_be_unique(
+        cls,
+        value: tuple[AlertChannel, ...],
+    ) -> tuple[AlertChannel, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("channels must be unique")
+        return value
+
+
+class AlertRuleCreate(AlertRuleDefinition):
+    pass
+
+
+class AlertRuleUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_version: int = Field(ge=1)
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    operator: AlertOperator | None = None
+    threshold: float | None = Field(default=None, allow_inf_nan=False)
+    aggregation: AlertAggregation | None = None
+    window: AlertDuration | None = None
+    duration: AlertDuration | None = None
+    severity: AlertSeverity | None = None
+    channels: tuple[AlertChannel, ...] | None = Field(default=None, min_length=1)
+    cooldown_seconds: int | None = Field(default=None, ge=60, le=86_400)
+    enabled: bool | None = None
+
+    @field_validator("channels")
+    @classmethod
+    def channels_must_be_unique(
+        cls,
+        value: tuple[AlertChannel, ...] | None,
+    ) -> tuple[AlertChannel, ...] | None:
+        if value is not None and len(set(value)) != len(value):
+            raise ValueError("channels must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def require_non_null_change(self) -> Self:
+        changed_fields = self.model_fields_set - {"expected_version"}
+        if not changed_fields:
+            raise ValueError("at least one mutable field is required")
+        if any(getattr(self, field_name) is None for field_name in changed_fields):
+            raise ValueError("mutable fields cannot be null")
+        return self
+
+    def updates(self) -> dict[str, object]:
+        return self.model_dump(
+            mode="python",
+            exclude={"expected_version"},
+            exclude_unset=True,
+        )
+
+
+class AlertRuleReplace(AlertRuleDefinition):
+    expected_version: int = Field(ge=1)
+
+
+class AlertRuleResponse(VersionedResponse):
+    tenant_id: str
+    rule_id: str
+    pond_id: str
+    device_id: str | None = None
+    metric: AlertMetric
+    name: str
+    operator: AlertOperator
+    threshold: float
+    aggregation: AlertAggregation
+    window: str
+    duration: str
+    severity: AlertSeverity
+    channels: tuple[AlertChannel, ...]
+    cooldown_seconds: int
+    enabled: bool
+    replaces_rule_id: str | None = None
+    replaced_by_rule_id: str | None = None
+
+
+class AlertRuleListResponse(BaseModel):
+    items: list[AlertRuleResponse]
+
+
+class AlertRuleReplacementResponse(BaseModel):
+    replaced: AlertRuleResponse
+    replacement: AlertRuleResponse

--- a/src/limnopulse_api/domain/alerts.py
+++ b/src/limnopulse_api/domain/alerts.py
@@ -1,0 +1,109 @@
+from collections.abc import Mapping
+from enum import StrEnum
+import re
+from typing import Annotated, Any
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
+
+from limnopulse_api.domain.entities import VersionedEntity
+
+
+class AlertMetric(StrEnum):
+    TEMP_C = "temp_c"
+    PH = "ph"
+    DO_MG_L = "do_mg_l"
+    TURBIDITY_NTU = "turbidity_ntu"
+    SALINITY_PPT = "salinity_ppt"
+    BATTERY_V = "battery_v"
+    RSSI = "rssi"
+
+
+class AlertOperator(StrEnum):
+    LESS_THAN = "<"
+    LESS_THAN_OR_EQUAL = "<="
+    GREATER_THAN = ">"
+    GREATER_THAN_OR_EQUAL = ">="
+
+
+class AlertAggregation(StrEnum):
+    MIN = "min"
+    MAX = "max"
+    MEAN = "mean"
+    LAST = "last"
+
+
+class AlertSeverity(StrEnum):
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+class AlertChannel(StrEnum):
+    EMAIL = "email"
+    TELEGRAM = "telegram"
+
+
+_DURATION_PATTERN = re.compile(r"^(?P<amount>[1-9][0-9]*)(?P<unit>[smh])$")
+_DURATION_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3_600}
+_MIN_DURATION_SECONDS = 60
+_MAX_DURATION_SECONDS = 24 * 60 * 60
+
+
+def _validate_alert_duration(value: str) -> str:
+    match = _DURATION_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError("duration must use a positive integer followed by s, m, or h")
+    seconds = int(match.group("amount")) * _DURATION_UNIT_SECONDS[match.group("unit")]
+    if not _MIN_DURATION_SECONDS <= seconds <= _MAX_DURATION_SECONDS:
+        raise ValueError("duration must be between 60 seconds and 24 hours")
+    return value
+
+
+AlertDuration = Annotated[str, AfterValidator(_validate_alert_duration)]
+
+
+class AlertRule(VersionedEntity):
+    tenant_id: str
+    rule_id: str
+    pond_id: str
+    device_id: str | None = None
+    metric: AlertMetric
+    name: str = Field(min_length=1, max_length=120)
+    operator: AlertOperator
+    threshold: float = Field(allow_inf_nan=False)
+    aggregation: AlertAggregation
+    window: AlertDuration
+    duration: AlertDuration
+    severity: AlertSeverity
+    channels: tuple[AlertChannel, ...] = Field(min_length=1)
+    cooldown_seconds: int = Field(ge=60, le=86_400)
+    enabled: bool
+    replaces_rule_id: str | None = None
+    replaced_by_rule_id: str | None = None
+
+    @field_validator("channels")
+    @classmethod
+    def channels_must_be_unique(
+        cls,
+        value: tuple[AlertChannel, ...],
+    ) -> tuple[AlertChannel, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("channels must be unique")
+        return value
+
+
+class AuditContext(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    actor_id: str
+    ip: str | None = None
+    user_agent: str | None = None
+
+
+class AlertRuleReplacement(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    replaced: AlertRule
+    replacement: AlertRule
+
+
+AlertRuleUpdates = Mapping[str, Any]

--- a/src/limnopulse_api/domain/ids.py
+++ b/src/limnopulse_api/domain/ids.py
@@ -11,3 +11,7 @@ def new_pond_id() -> str:
 
 def new_device_id() -> str:
     return f"dev_{uuid4().hex}"
+
+
+def new_alert_rule_id() -> str:
+    return f"rule_{uuid4().hex}"

--- a/src/limnopulse_api/main.py
+++ b/src/limnopulse_api/main.py
@@ -9,6 +9,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 from influxdb_client import InfluxDBClient
 
 from limnopulse_api.adapters.dynamodb import DynamoDomainRepository
+from limnopulse_api.adapters.alert_rules import DynamoAlertRuleRepository
 from limnopulse_api.adapters.influxdb import InfluxTelemetryRepository
 from limnopulse_api.adapters.redis import RedisCacheRepository
 from limnopulse_api.api.router import api_router
@@ -41,6 +42,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             hasattr(app.state, attribute_name)
             for attribute_name in (
                 "domain_repository",
+                "alert_rule_repository",
                 "membership_service",
                 "auth_provider",
                 "cache_repository",
@@ -55,9 +57,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         redis_client = redis.from_url(resolved_settings.redis_url)
         app.state.redis_client = redis_client
         app.state.cache_repository = RedisCacheRepository(redis_client)
+        dynamodb_client = boto3.client(
+            "dynamodb",
+            **_dynamodb_client_kwargs(resolved_settings),
+        )
         app.state.domain_repository = DynamoDomainRepository(
             table_name=resolved_settings.dynamodb_domain_table,
-            client=boto3.client("dynamodb", **_dynamodb_client_kwargs(resolved_settings)),
+            client=dynamodb_client,
+        )
+        app.state.alert_rule_repository = DynamoAlertRuleRepository(
+            domain_table_name=resolved_settings.dynamodb_domain_table,
+            audit_table_name=resolved_settings.dynamodb_audit_table,
+            client=dynamodb_client,
         )
         app.state.membership_service = MembershipService(
             domain_repository=app.state.domain_repository,

--- a/src/limnopulse_api/repositories/alerts.py
+++ b/src/limnopulse_api/repositories/alerts.py
@@ -25,6 +25,14 @@ class AlertRuleRepository(Protocol):
     ) -> AlertRule:
         raise NotImplementedError
 
+    async def get_replacement_replay(
+        self,
+        tenant_id: str,
+        idempotency_key: str,
+        request_hash: str,
+    ) -> AlertRuleReplacement | None:
+        raise NotImplementedError
+
     async def replace_rule(
         self,
         tenant_id: str,

--- a/src/limnopulse_api/repositories/alerts.py
+++ b/src/limnopulse_api/repositories/alerts.py
@@ -1,0 +1,38 @@
+from typing import Protocol
+
+from limnopulse_api.domain.alerts import (
+    AlertRule,
+    AlertRuleReplacement,
+    AlertRuleUpdates,
+    AuditContext,
+)
+
+
+class AlertRuleRepository(Protocol):
+    async def list_rules(self, tenant_id: str) -> list[AlertRule]:
+        raise NotImplementedError
+
+    async def create_rule(self, rule: AlertRule, audit: AuditContext) -> AlertRule:
+        raise NotImplementedError
+
+    async def update_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        updates: AlertRuleUpdates,
+        audit: AuditContext,
+    ) -> AlertRule:
+        raise NotImplementedError
+
+    async def replace_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        replacement: AlertRule,
+        idempotency_key: str,
+        request_hash: str,
+        audit: AuditContext,
+    ) -> AlertRuleReplacement:
+        raise NotImplementedError

--- a/src/limnopulse_api/services/alert_rules.py
+++ b/src/limnopulse_api/services/alert_rules.py
@@ -82,16 +82,23 @@ class AlertRuleService:
         idempotency_key: str,
         audit: AuditContext,
     ) -> AlertRuleReplacement:
-        await self._validate_target(
-            tenant_id,
-            pond_id=str(definition["pond_id"]),
-            device_id=self._optional_string(definition.get("device_id")),
-        )
         request_hash = self._replacement_request_hash(
             tenant_id,
             rule_id,
             expected_version,
             definition,
+        )
+        replay = await self.repository.get_replacement_replay(
+            tenant_id,
+            idempotency_key,
+            request_hash,
+        )
+        if replay is not None:
+            return replay
+        await self._validate_target(
+            tenant_id,
+            pond_id=str(definition["pond_id"]),
+            device_id=self._optional_string(definition.get("device_id")),
         )
         now = self.clock()
         replacement = AlertRule.model_validate(

--- a/src/limnopulse_api/services/alert_rules.py
+++ b/src/limnopulse_api/services/alert_rules.py
@@ -1,0 +1,158 @@
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from hashlib import sha256
+import json
+from typing import Any
+
+from limnopulse_api.core.errors import NotFoundError
+from limnopulse_api.domain.alerts import AlertRule, AlertRuleReplacement, AuditContext
+from limnopulse_api.domain.ids import new_alert_rule_id
+from limnopulse_api.repositories.alerts import AlertRuleRepository
+from limnopulse_api.repositories.domain import DomainRepository
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+class AlertRuleService:
+    def __init__(
+        self,
+        repository: AlertRuleRepository,
+        domain_repository: DomainRepository,
+        *,
+        clock: Callable[[], datetime] = utc_now,
+        id_factory: Callable[[], str] = new_alert_rule_id,
+    ) -> None:
+        self.repository = repository
+        self.domain_repository = domain_repository
+        self.clock = clock
+        self.id_factory = id_factory
+
+    async def list(self, tenant_id: str) -> list[AlertRule]:
+        return await self.repository.list_rules(tenant_id)
+
+    async def create(
+        self,
+        tenant_id: str,
+        definition: Mapping[str, Any],
+        audit: AuditContext,
+    ) -> AlertRule:
+        await self._validate_target(
+            tenant_id,
+            pond_id=str(definition["pond_id"]),
+            device_id=self._optional_string(definition.get("device_id")),
+        )
+        now = self.clock()
+        rule = AlertRule.model_validate(
+            {
+                **dict(definition),
+                "tenant_id": tenant_id,
+                "rule_id": self.id_factory(),
+                "created_at": now,
+                "updated_at": now,
+                "version": 1,
+                "status": "active",
+            }
+        )
+        return await self.repository.create_rule(rule, audit)
+
+    async def update(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        updates: Mapping[str, Any],
+        audit: AuditContext,
+    ) -> AlertRule:
+        return await self.repository.update_rule(
+            tenant_id,
+            rule_id,
+            expected_version,
+            dict(updates),
+            audit,
+        )
+
+    async def replace(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        definition: Mapping[str, Any],
+        idempotency_key: str,
+        audit: AuditContext,
+    ) -> AlertRuleReplacement:
+        await self._validate_target(
+            tenant_id,
+            pond_id=str(definition["pond_id"]),
+            device_id=self._optional_string(definition.get("device_id")),
+        )
+        request_hash = self._replacement_request_hash(
+            tenant_id,
+            rule_id,
+            expected_version,
+            definition,
+        )
+        now = self.clock()
+        replacement = AlertRule.model_validate(
+            {
+                **dict(definition),
+                "tenant_id": tenant_id,
+                "rule_id": self.id_factory(),
+                "replaces_rule_id": rule_id,
+                "created_at": now,
+                "updated_at": now,
+                "version": 1,
+                "status": "active",
+            }
+        )
+        return await self.repository.replace_rule(
+            tenant_id,
+            rule_id,
+            expected_version,
+            replacement,
+            idempotency_key,
+            request_hash,
+            audit,
+        )
+
+    async def _validate_target(
+        self,
+        tenant_id: str,
+        *,
+        pond_id: str,
+        device_id: str | None,
+    ) -> None:
+        pond = await self.domain_repository.get_pond(tenant_id, pond_id)
+        if pond is None:
+            raise NotFoundError("alert rule target not found")
+        if device_id is None:
+            return
+        device = await self.domain_repository.get_device(tenant_id, device_id)
+        if device is None or device.pond_id != pond_id:
+            raise NotFoundError("alert rule target not found")
+
+    def _replacement_request_hash(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        definition: Mapping[str, Any],
+    ) -> str:
+        canonical = json.dumps(
+            {
+                "tenant_id": tenant_id,
+                "rule_id": rule_id,
+                "expected_version": expected_version,
+                "replacement": dict(definition),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+        return sha256(canonical).hexdigest()
+
+    def _optional_string(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)

--- a/tests/api/test_alert_rules.py
+++ b/tests/api/test_alert_rules.py
@@ -130,6 +130,20 @@ class FakeAlertRuleRepository:
         self.audits.append(audit)
         return updated
 
+    async def get_replacement_replay(
+        self,
+        tenant_id: str,
+        idempotency_key: str,
+        request_hash: str,
+    ) -> AlertRuleReplacement | None:
+        replay = self.idempotency.get(idempotency_key)
+        if replay is None:
+            return None
+        stored_hash, stored_result = replay
+        if stored_hash != request_hash:
+            raise ConflictError("idempotency conflict")
+        return stored_result
+
     async def replace_rule(
         self,
         tenant_id: str,
@@ -405,6 +419,22 @@ def test_replace_returns_old_and_new_rule_and_replays() -> None:
     assert first.json()["replacement"]["metric"] == "ph"
     assert first.json()["replacement"]["replaces_rule_id"] == "rule_1"
     assert len(repository.idempotency) == 1
+
+
+def test_replace_replay_does_not_depend_on_current_target_state() -> None:
+    app, _, domain_repository = app_for_role(TenantRole.ADMIN)
+    client = TestClient(app)
+    path = "/v1/tenants/tnt_1/alert-rules/rule_1/replace"
+    payload = {"expected_version": 1, **create_payload(metric="ph")}
+    headers = dev_headers(**{"Idempotency-Key": "replace-123"})
+
+    first = client.post(path, json=payload, headers=headers)
+    domain_repository.devices.pop("dev_1")
+    replay = client.post(path, json=payload, headers=headers)
+
+    assert first.status_code == 201
+    assert replay.status_code == 201
+    assert replay.json() == first.json()
 
 
 def test_replace_rejects_same_idempotency_key_with_other_payload() -> None:

--- a/tests/api/test_alert_rules.py
+++ b/tests/api/test_alert_rules.py
@@ -1,0 +1,443 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from limnopulse_api.core.config import Settings
+from limnopulse_api.core.errors import ConflictError, NotFoundError
+from limnopulse_api.domain.alerts import (
+    AlertAggregation,
+    AlertChannel,
+    AlertMetric,
+    AlertOperator,
+    AlertRule,
+    AlertRuleReplacement,
+    AlertSeverity,
+    AuditContext,
+)
+from limnopulse_api.domain.entities import Device, Membership, Pond
+from limnopulse_api.domain.roles import TenantRole
+from limnopulse_api.main import create_app
+
+
+NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+
+
+class FakeMembershipService:
+    def __init__(self, role: TenantRole) -> None:
+        self.membership = Membership(
+            tenant_id="tnt_1",
+            cognito_sub="sub_1",
+            role=role,
+            created_at=NOW,
+            updated_at=NOW,
+            version=1,
+        )
+
+    async def get_active_membership(
+        self,
+        cognito_sub: str,
+        tenant_id: str,
+    ) -> Membership | None:
+        if cognito_sub != "sub_1" or tenant_id != "tnt_1":
+            return None
+        return self.membership
+
+
+class FakeDomainRepository:
+    def __init__(self) -> None:
+        self.ponds = {
+            "pond_1": Pond(
+                tenant_id="tnt_1",
+                pond_id="pond_1",
+                name="West",
+                created_at=NOW,
+                updated_at=NOW,
+                version=1,
+            )
+        }
+        self.devices = {
+            "dev_1": Device(
+                tenant_id="tnt_1",
+                pond_id="pond_1",
+                device_id="dev_1",
+                name="Probe",
+                created_at=NOW,
+                updated_at=NOW,
+                version=1,
+            ),
+            "dev_other_pond": Device(
+                tenant_id="tnt_1",
+                pond_id="pond_2",
+                device_id="dev_other_pond",
+                name="Other probe",
+                created_at=NOW,
+                updated_at=NOW,
+                version=1,
+            ),
+        }
+
+    async def get_pond(self, tenant_id: str, pond_id: str) -> Pond | None:
+        pond = self.ponds.get(pond_id)
+        if pond is None or pond.tenant_id != tenant_id:
+            return None
+        return pond
+
+    async def get_device(self, tenant_id: str, device_id: str) -> Device | None:
+        device = self.devices.get(device_id)
+        if device is None or device.tenant_id != tenant_id:
+            return None
+        return device
+
+
+class FakeAlertRuleRepository:
+    def __init__(self) -> None:
+        self.rules: dict[str, AlertRule] = {"rule_1": make_rule()}
+        self.audits: list[AuditContext] = []
+        self.idempotency: dict[str, tuple[str, AlertRuleReplacement]] = {}
+
+    async def list_rules(self, tenant_id: str) -> list[AlertRule]:
+        return [rule for rule in self.rules.values() if rule.tenant_id == tenant_id]
+
+    async def create_rule(self, rule: AlertRule, audit: AuditContext) -> AlertRule:
+        self.rules[rule.rule_id] = rule
+        self.audits.append(audit)
+        return rule
+
+    async def update_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        updates: dict[str, Any],
+        audit: AuditContext,
+    ) -> AlertRule:
+        existing = self.rules.get(rule_id)
+        if existing is None or existing.tenant_id != tenant_id:
+            raise NotFoundError("not found")
+        if existing.version != expected_version:
+            raise ConflictError("version conflict")
+        updated = AlertRule.model_validate(
+            {
+                **existing.model_dump(mode="python"),
+                **updates,
+                "updated_at": NOW,
+                "version": expected_version + 1,
+            }
+        )
+        self.rules[rule_id] = updated
+        self.audits.append(audit)
+        return updated
+
+    async def replace_rule(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        expected_version: int,
+        replacement: AlertRule,
+        idempotency_key: str,
+        request_hash: str,
+        audit: AuditContext,
+    ) -> AlertRuleReplacement:
+        replay = self.idempotency.get(idempotency_key)
+        if replay is not None:
+            stored_hash, stored_result = replay
+            if stored_hash != request_hash:
+                raise ConflictError("idempotency conflict")
+            return stored_result
+        existing = self.rules.get(rule_id)
+        if existing is None or existing.tenant_id != tenant_id:
+            raise NotFoundError("not found")
+        if existing.version != expected_version:
+            raise ConflictError("version conflict")
+        replaced = AlertRule.model_validate(
+            {
+                **existing.model_dump(mode="python"),
+                "enabled": False,
+                "status": "replaced",
+                "replaced_by_rule_id": replacement.rule_id,
+                "updated_at": NOW,
+                "version": expected_version + 1,
+            }
+        )
+        result = AlertRuleReplacement(replaced=replaced, replacement=replacement)
+        self.rules[rule_id] = replaced
+        self.rules[replacement.rule_id] = replacement
+        self.idempotency[idempotency_key] = (request_hash, result)
+        self.audits.append(audit)
+        return result
+
+
+def make_rule() -> AlertRule:
+    return AlertRule(
+        tenant_id="tnt_1",
+        rule_id="rule_1",
+        pond_id="pond_1",
+        device_id="dev_1",
+        metric=AlertMetric.DO_MG_L,
+        name="Low oxygen",
+        operator=AlertOperator.LESS_THAN,
+        threshold=5.0,
+        aggregation=AlertAggregation.MIN,
+        window="5m",
+        duration="3m",
+        severity=AlertSeverity.CRITICAL,
+        channels=(AlertChannel.EMAIL, AlertChannel.TELEGRAM),
+        cooldown_seconds=1_800,
+        enabled=True,
+        created_at=NOW,
+        updated_at=NOW,
+        version=1,
+    )
+
+
+def create_payload(**updates: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "pond_id": "pond_1",
+        "device_id": "dev_1",
+        "metric": "do_mg_l",
+        "name": "Low oxygen",
+        "operator": "<",
+        "threshold": 5.0,
+        "aggregation": "min",
+        "window": "5m",
+        "duration": "3m",
+        "severity": "critical",
+        "channels": ["email", "telegram"],
+        "cooldown_seconds": 1_800,
+        "enabled": True,
+    }
+    payload.update(updates)
+    return payload
+
+
+def app_for_role(
+    role: TenantRole,
+) -> tuple[Any, FakeAlertRuleRepository, FakeDomainRepository]:
+    app = create_app(Settings(app_env="test", auth_mode="dev"))
+    repository = FakeAlertRuleRepository()
+    domain_repository = FakeDomainRepository()
+    app.state.domain_repository = domain_repository
+    app.state.alert_rule_repository = repository
+    app.state.membership_service = FakeMembershipService(role)
+    return app, repository, domain_repository
+
+
+def dev_headers(**updates: str) -> dict[str, str]:
+    headers = {"X-Dev-User-Sub": "sub_1", "User-Agent": "limnopulse-tests"}
+    headers.update(updates)
+    return headers
+
+
+@pytest.mark.parametrize("role", list(TenantRole))
+def test_all_tenant_roles_can_list_alert_rules(role: TenantRole) -> None:
+    app, _, _ = app_for_role(role)
+
+    response = TestClient(app).get(
+        "/v1/tenants/tnt_1/alert-rules",
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["rule_id"] == "rule_1"
+
+
+@pytest.mark.parametrize("role", [TenantRole.MEMBER, TenantRole.VIEWER])
+def test_read_only_roles_cannot_mutate_alert_rules(role: TenantRole) -> None:
+    app, _, _ = app_for_role(role)
+    client = TestClient(app)
+    path = "/v1/tenants/tnt_1/alert-rules"
+
+    assert client.post(path, json=create_payload(), headers=dev_headers()).status_code == 403
+    assert (
+        client.patch(
+            f"{path}/rule_1",
+            json={"expected_version": 1, "threshold": 4.5},
+            headers=dev_headers(),
+        ).status_code
+        == 403
+    )
+    assert (
+        client.post(
+            f"{path}/rule_1/replace",
+            json={"expected_version": 1, **create_payload(metric="ph")},
+            headers=dev_headers(**{"Idempotency-Key": "replace-123"}),
+        ).status_code
+        == 403
+    )
+
+
+@pytest.mark.parametrize("role", [TenantRole.OWNER, TenantRole.ADMIN])
+def test_write_roles_can_create_alert_rule_with_server_id(role: TenantRole) -> None:
+    app, repository, _ = app_for_role(role)
+
+    response = TestClient(app).post(
+        "/v1/tenants/tnt_1/alert-rules",
+        json=create_payload(),
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["rule_id"].startswith("rule_")
+    assert body["version"] == 1
+    assert body["status"] == "active"
+    assert body["channels"] == ["email", "telegram"]
+    assert body["rule_id"] in repository.rules
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_status"),
+    [
+        ({"unexpected": "value"}, 422),
+        ({"window": "59s"}, 422),
+        ({"duration": "25h"}, 422),
+        ({"cooldown_seconds": 59}, 422),
+        ({"channels": []}, 422),
+        ({"channels": ["email", "email"]}, 422),
+        ({"metric": "unknown"}, 422),
+    ],
+)
+def test_create_rejects_invalid_alert_rule_payloads(
+    updates: dict[str, Any],
+    expected_status: int,
+) -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+
+    response = TestClient(app).post(
+        "/v1/tenants/tnt_1/alert-rules",
+        json=create_payload(**updates),
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"pond_id": "pond_missing"},
+        {"device_id": "dev_missing"},
+        {"device_id": "dev_other_pond"},
+    ],
+)
+def test_create_hides_missing_or_mismatched_targets(updates: dict[str, Any]) -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+
+    response = TestClient(app).post(
+        "/v1/tenants/tnt_1/alert-rules",
+        json=create_payload(**updates),
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 404
+
+
+def test_patch_updates_mutable_fields_and_increments_version() -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+
+    response = TestClient(app).patch(
+        "/v1/tenants/tnt_1/alert-rules/rule_1",
+        json={"expected_version": 1, "threshold": 4.5, "enabled": False},
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["threshold"] == 4.5
+    assert response.json()["enabled"] is False
+    assert response.json()["version"] == 2
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"expected_version": 1},
+        {"expected_version": 1, "metric": "ph"},
+        {"expected_version": 1, "pond_id": "pond_1"},
+        {"expected_version": 1, "threshold": None},
+    ],
+)
+def test_patch_rejects_empty_immutable_or_null_changes(payload: dict[str, Any]) -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+
+    response = TestClient(app).patch(
+        "/v1/tenants/tnt_1/alert-rules/rule_1",
+        json=payload,
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+def test_replace_requires_valid_idempotency_key() -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+    client = TestClient(app)
+    path = "/v1/tenants/tnt_1/alert-rules/rule_1/replace"
+    payload = {"expected_version": 1, **create_payload(metric="ph")}
+
+    assert client.post(path, json=payload, headers=dev_headers()).status_code == 422
+    assert (
+        client.post(
+            path,
+            json=payload,
+            headers=dev_headers(**{"Idempotency-Key": "short"}),
+        ).status_code
+        == 422
+    )
+
+
+def test_replace_returns_old_and_new_rule_and_replays() -> None:
+    app, repository, _ = app_for_role(TenantRole.ADMIN)
+    client = TestClient(app)
+    path = "/v1/tenants/tnt_1/alert-rules/rule_1/replace"
+    payload = {"expected_version": 1, **create_payload(metric="ph", threshold=6.5)}
+    headers = dev_headers(**{"Idempotency-Key": "replace-123"})
+
+    first = client.post(path, json=payload, headers=headers)
+    replay = client.post(path, json=payload, headers=headers)
+
+    assert first.status_code == 201
+    assert replay.status_code == 201
+    assert replay.json() == first.json()
+    assert first.json()["replaced"]["status"] == "replaced"
+    assert first.json()["replaced"]["enabled"] is False
+    assert first.json()["replacement"]["metric"] == "ph"
+    assert first.json()["replacement"]["replaces_rule_id"] == "rule_1"
+    assert len(repository.idempotency) == 1
+
+
+def test_replace_rejects_same_idempotency_key_with_other_payload() -> None:
+    app, _, _ = app_for_role(TenantRole.ADMIN)
+    client = TestClient(app)
+    path = "/v1/tenants/tnt_1/alert-rules/rule_1/replace"
+    headers = dev_headers(**{"Idempotency-Key": "replace-123"})
+
+    first = client.post(
+        path,
+        json={"expected_version": 1, **create_payload(metric="ph")},
+        headers=headers,
+    )
+    conflict = client.post(
+        path,
+        json={"expected_version": 1, **create_payload(metric="temp_c")},
+        headers=headers,
+    )
+
+    assert first.status_code == 201
+    assert conflict.status_code == 409
+
+
+def test_mutation_passes_redacted_request_context_to_repository() -> None:
+    app, repository, _ = app_for_role(TenantRole.OWNER)
+
+    response = TestClient(app).post(
+        "/v1/tenants/tnt_1/alert-rules",
+        json=create_payload(),
+        headers=dev_headers(),
+    )
+
+    assert response.status_code == 201
+    assert repository.audits[-1].actor_id == "sub_1"
+    assert repository.audits[-1].ip is not None
+    assert repository.audits[-1].user_agent == "limnopulse-tests"

--- a/tests/api/test_app_runtime.py
+++ b/tests/api/test_app_runtime.py
@@ -263,7 +263,9 @@ def test_me_reuses_app_scoped_auth_provider(monkeypatch) -> None:
     def fail_build_auth_provider(settings, cache=None):
         raise AssertionError("auth provider should be reused from app state")
 
-    monkeypatch.setattr("limnopulse_api.api.dependencies.build_auth_provider", fail_build_auth_provider)
+    monkeypatch.setattr(
+        "limnopulse_api.api.dependencies.build_auth_provider", fail_build_auth_provider
+    )
 
     with TestClient(app) as client:
         first = client.get("/v1/me")

--- a/tests/api/test_app_runtime.py
+++ b/tests/api/test_app_runtime.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from botocore.exceptions import EndpointConnectionError
 
 from limnopulse_api.adapters.dynamodb import DynamoDomainRepository
+from limnopulse_api.adapters.alert_rules import DynamoAlertRuleRepository
 from limnopulse_api.adapters.redis import RedisCacheRepository
 from limnopulse_api.auth.cognito import CognitoJwtAuthProvider
 from limnopulse_api.auth.models import Principal
@@ -131,6 +132,7 @@ def test_app_lifespan_wires_runtime_dependencies(monkeypatch) -> None:
     assert redis_calls == []
     assert influx_calls == []
     assert not hasattr(app.state, "domain_repository")
+    assert not hasattr(app.state, "alert_rule_repository")
     assert not hasattr(app.state, "membership_service")
     assert not hasattr(app.state, "auth_provider")
     assert not hasattr(app.state, "telemetry_repository")
@@ -148,6 +150,8 @@ def test_app_lifespan_wires_runtime_dependencies(monkeypatch) -> None:
         assert redis_calls == ["redis://localhost:6379/0"]
         assert isinstance(app.state.domain_repository, DynamoDomainRepository)
         assert app.state.domain_repository.client is fake_dynamo
+        assert isinstance(app.state.alert_rule_repository, DynamoAlertRuleRepository)
+        assert app.state.alert_rule_repository.client is fake_dynamo
         assert isinstance(app.state.cache_repository, RedisCacheRepository)
         assert app.state.cache_repository.redis is fake_redis
         assert isinstance(app.state.membership_service, MembershipService)

--- a/tests/unit/test_alert_rule_domain.py
+++ b/tests/unit/test_alert_rule_domain.py
@@ -1,0 +1,100 @@
+import re
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from limnopulse_api.domain.alerts import (
+    AlertAggregation,
+    AlertChannel,
+    AlertMetric,
+    AlertOperator,
+    AlertRule,
+    AlertSeverity,
+)
+from limnopulse_api.domain.ids import new_alert_rule_id
+
+
+def make_rule(**updates: object) -> AlertRule:
+    now = datetime(2026, 7, 15, tzinfo=UTC)
+    values: dict[str, object] = {
+        "tenant_id": "tnt_1",
+        "rule_id": "rule_1",
+        "pond_id": "pond_1",
+        "device_id": "dev_1",
+        "metric": AlertMetric.DO_MG_L,
+        "name": "Low oxygen",
+        "operator": AlertOperator.LESS_THAN,
+        "threshold": 5.0,
+        "aggregation": AlertAggregation.MIN,
+        "window": "5m",
+        "duration": "3m",
+        "severity": AlertSeverity.CRITICAL,
+        "channels": (AlertChannel.EMAIL, AlertChannel.TELEGRAM),
+        "cooldown_seconds": 1_800,
+        "enabled": True,
+        "created_at": now,
+        "updated_at": now,
+        "version": 1,
+    }
+    values.update(updates)
+    return AlertRule.model_validate(values)
+
+
+@pytest.mark.parametrize("duration", ["59s", "25h", "0m", "1d", "five-minutes"])
+def test_alert_rule_rejects_duration_outside_bounds_or_format(duration: str) -> None:
+    with pytest.raises(ValidationError):
+        make_rule(window=duration)
+
+
+@pytest.mark.parametrize("duration", ["60s", "1m", "5m", "1h", "24h"])
+def test_alert_rule_accepts_canonical_duration_within_bounds(duration: str) -> None:
+    assert make_rule(duration=duration).duration == duration
+
+
+def test_alert_rule_rejects_duplicate_or_empty_channels() -> None:
+    with pytest.raises(ValidationError):
+        make_rule(channels=())
+    with pytest.raises(ValidationError):
+        make_rule(channels=(AlertChannel.EMAIL, AlertChannel.EMAIL))
+
+
+def test_alert_rule_rejects_non_finite_threshold_and_invalid_cooldown() -> None:
+    with pytest.raises(ValidationError):
+        make_rule(threshold=float("inf"))
+    with pytest.raises(ValidationError):
+        make_rule(cooldown_seconds=59)
+    with pytest.raises(ValidationError):
+        make_rule(cooldown_seconds=86_401)
+
+
+def test_alert_rule_is_immutable() -> None:
+    rule = make_rule()
+
+    with pytest.raises(ValidationError):
+        rule.threshold = 4.5
+
+
+def test_new_alert_rule_id_has_canonical_prefix() -> None:
+    assert re.fullmatch(r"rule_[0-9a-f]{32}", new_alert_rule_id())
+
+
+def test_alert_rule_enums_match_phase_3a_contract() -> None:
+    assert {metric.value for metric in AlertMetric} == {
+        "temp_c",
+        "ph",
+        "do_mg_l",
+        "turbidity_ntu",
+        "salinity_ppt",
+        "battery_v",
+        "rssi",
+    }
+    assert {operator.value for operator in AlertOperator} == {"<", "<=", ">", ">="}
+    assert {aggregation.value for aggregation in AlertAggregation} == {
+        "min",
+        "max",
+        "mean",
+        "last",
+    }
+    assert {severity.value for severity in AlertSeverity} == {"warning", "critical"}
+    assert {channel.value for channel in AlertChannel} == {"email", "telegram"}

--- a/tests/unit/test_alert_rule_repository.py
+++ b/tests/unit/test_alert_rule_repository.py
@@ -1,0 +1,386 @@
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+
+from limnopulse_api.adapters.alert_rules import DynamoAlertRuleRepository
+from limnopulse_api.core.errors import ConflictError, NotFoundError
+from limnopulse_api.domain.alerts import (
+    AlertAggregation,
+    AlertChannel,
+    AlertMetric,
+    AlertOperator,
+    AlertRule,
+    AlertSeverity,
+    AuditContext,
+)
+
+
+class TransactionFailure(Exception):
+    def __init__(self) -> None:
+        self.response = {"Error": {"Code": "TransactionCanceledException"}}
+        super().__init__("transaction cancelled")
+
+
+class RecordingDynamoClient:
+    def __init__(self) -> None:
+        self.serializer = TypeSerializer()
+        self.deserializer = TypeDeserializer()
+        self.items: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.query_calls: list[dict[str, Any]] = []
+        self.get_item_calls: list[dict[str, Any]] = []
+        self.transact_write_items_calls: list[dict[str, Any]] = []
+        self.scan_calls = 0
+
+    def seed(self, table_name: str, item: dict[str, Any]) -> None:
+        self.items[(table_name, item["PK"], item["SK"])] = deepcopy(item)
+
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        self.query_calls.append(kwargs)
+        values = self._decode_item(kwargs["ExpressionAttributeValues"])
+        table_name = kwargs["TableName"]
+        items = [
+            item
+            for (table, pk, sk), item in self.items.items()
+            if table == table_name
+            and pk == values[":pk"]
+            and sk.startswith(values[":sk_prefix"])
+        ]
+        items.sort(key=lambda item: item["SK"])
+        return {"Items": [self._encode_item(item) for item in items]}
+
+    def get_item(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_item_calls.append(kwargs)
+        key = self._decode_item(kwargs["Key"])
+        item = self.items.get((kwargs["TableName"], key["PK"], key["SK"]))
+        if item is None:
+            return {}
+        return {"Item": self._encode_item(item)}
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        self.transact_write_items_calls.append(kwargs)
+        candidate = deepcopy(self.items)
+        for operation in kwargs["TransactItems"]:
+            if "Put" in operation:
+                self._apply_put(candidate, operation["Put"])
+            else:
+                self._apply_update(candidate, operation["Update"])
+        self.items = candidate
+        return {}
+
+    def scan(self, **kwargs: Any) -> dict[str, Any]:
+        self.scan_calls += 1
+        return {}
+
+    def _apply_put(
+        self,
+        items: dict[tuple[str, str, str], dict[str, Any]],
+        put: dict[str, Any],
+    ) -> None:
+        item = self._decode_item(put["Item"])
+        key = (put["TableName"], item["PK"], item["SK"])
+        existing = items.get(key)
+        condition = put.get("ConditionExpression", "")
+        if existing is not None and "attribute_not_exists" in condition:
+            values = self._decode_item(put.get("ExpressionAttributeValues", {}))
+            now = values.get(":now")
+            if now is None or existing.get("expires_at", now + 1) > now:
+                raise TransactionFailure()
+        items[key] = item
+
+    def _apply_update(
+        self,
+        items: dict[tuple[str, str, str], dict[str, Any]],
+        update: dict[str, Any],
+    ) -> None:
+        key_fields = self._decode_item(update["Key"])
+        key = (update["TableName"], key_fields["PK"], key_fields["SK"])
+        existing = items.get(key)
+        if existing is None:
+            raise TransactionFailure()
+        values = self._decode_item(update["ExpressionAttributeValues"])
+        if existing.get("version") != values.get(":expected_version"):
+            raise TransactionFailure()
+        if ":active" in values and existing.get("status") != values[":active"]:
+            raise TransactionFailure()
+        updated = dict(existing)
+        for assignment in update["UpdateExpression"].removeprefix("SET ").split(", "):
+            name_token, value_token = assignment.split(" = ")
+            field_name = update["ExpressionAttributeNames"][name_token]
+            updated[field_name] = values[value_token]
+        items[key] = updated
+
+    def _encode_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: self.serializer.serialize(self._normalize_for_dynamodb(value))
+            for key, value in item.items()
+        }
+
+    def _decode_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        return {key: self.deserializer.deserialize(value) for key, value in item.items()}
+
+    def _normalize_for_dynamodb(self, value: Any) -> Any:
+        if isinstance(value, float):
+            return Decimal(str(value))
+        if isinstance(value, dict):
+            return {
+                key: self._normalize_for_dynamodb(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [self._normalize_for_dynamodb(item) for item in value]
+        return value
+
+
+NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+
+
+def make_rule(
+    *,
+    rule_id: str = "rule_1",
+    version: int = 1,
+    metric: AlertMetric = AlertMetric.DO_MG_L,
+    threshold: float = 5.0,
+    status: str = "active",
+    enabled: bool = True,
+    replaces_rule_id: str | None = None,
+    replaced_by_rule_id: str | None = None,
+) -> AlertRule:
+    return AlertRule(
+        tenant_id="tnt_1",
+        rule_id=rule_id,
+        pond_id="pond_1",
+        device_id="dev_1",
+        metric=metric,
+        name="Low oxygen",
+        operator=AlertOperator.LESS_THAN,
+        threshold=threshold,
+        aggregation=AlertAggregation.MIN,
+        window="5m",
+        duration="3m",
+        severity=AlertSeverity.CRITICAL,
+        channels=(AlertChannel.EMAIL, AlertChannel.TELEGRAM),
+        cooldown_seconds=1_800,
+        enabled=enabled,
+        replaces_rule_id=replaces_rule_id,
+        replaced_by_rule_id=replaced_by_rule_id,
+        status=status,
+        created_at=NOW,
+        updated_at=NOW,
+        version=version,
+    )
+
+
+def make_repository(client: RecordingDynamoClient) -> DynamoAlertRuleRepository:
+    return DynamoAlertRuleRepository(
+        domain_table_name="LimnopulseDomain",
+        audit_table_name="LimnopulseAudit",
+        client=client,
+        clock=lambda: NOW,
+    )
+
+
+def audit_context() -> AuditContext:
+    return AuditContext(actor_id="sub_1", ip="203.0.113.5", user_agent="pytest")
+
+
+def decode_put(client: RecordingDynamoClient, operation: dict[str, Any]) -> dict[str, Any]:
+    return client._decode_item(operation["Put"]["Item"])
+
+
+@pytest.mark.asyncio
+async def test_list_rules_queries_alert_rule_prefix_without_scan() -> None:
+    client = RecordingDynamoClient()
+    client.seed("LimnopulseDomain", make_repository(client)._rule_to_item(make_rule()))
+    repository = make_repository(client)
+
+    rules = await repository.list_rules("tnt_1")
+
+    assert [rule.rule_id for rule in rules] == ["rule_1"]
+    assert client.query_calls[0]["KeyConditionExpression"] == (
+        "PK = :pk AND begins_with(SK, :sk_prefix)"
+    )
+    assert client._decode_item(client.query_calls[0]["ExpressionAttributeValues"]) == {
+        ":pk": "TENANT#tnt_1",
+        ":sk_prefix": "ALERT_RULE#",
+    }
+    assert client.scan_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_create_rule_atomically_puts_rule_and_redacted_audit() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+
+    created = await repository.create_rule(make_rule(), audit_context())
+
+    assert created.version == 1
+    transaction = client.transact_write_items_calls[0]["TransactItems"]
+    assert [operation["Put"]["TableName"] for operation in transaction] == [
+        "LimnopulseDomain",
+        "LimnopulseAudit",
+    ]
+    audit = decode_put(client, transaction[1])
+    assert audit["action"] == "alert_rule.created"
+    assert audit["actor_id"] == "sub_1"
+    assert audit["resource_id"] == "rule_1"
+    assert len(audit["before_hash"]) == 64
+    assert len(audit["after_hash"]) == 64
+    assert audit["expires_at"] == int((NOW + timedelta(days=90)).timestamp())
+    assert "token" not in audit
+    assert "payload" not in audit
+
+
+@pytest.mark.asyncio
+async def test_create_rule_maps_conditional_transaction_to_conflict() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+    client.seed("LimnopulseDomain", repository._rule_to_item(make_rule()))
+
+    with pytest.raises(ConflictError):
+        await repository.create_rule(make_rule(), audit_context())
+
+
+@pytest.mark.asyncio
+async def test_update_rule_conditions_on_version_and_writes_audit() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+    client.seed("LimnopulseDomain", repository._rule_to_item(make_rule(version=2)))
+
+    updated = await repository.update_rule(
+        "tnt_1",
+        "rule_1",
+        2,
+        {"threshold": 4.5, "enabled": False},
+        audit_context(),
+    )
+
+    assert updated.version == 3
+    assert updated.threshold == 4.5
+    assert updated.enabled is False
+    transaction = client.transact_write_items_calls[0]["TransactItems"]
+    assert [set(operation) for operation in transaction] == [{"Update"}, {"Put"}]
+    update = transaction[0]["Update"]
+    assert client._decode_item(update["ExpressionAttributeValues"])[":expected_version"] == 2
+    assert "#status = :active" in update["ConditionExpression"]
+    assert decode_put(client, transaction[1])["action"] == "alert_rule.updated"
+
+
+@pytest.mark.asyncio
+async def test_update_rule_missing_target_raises_not_found() -> None:
+    repository = make_repository(RecordingDynamoClient())
+
+    with pytest.raises(NotFoundError):
+        await repository.update_rule(
+            "tnt_1", "rule_missing", 1, {"threshold": 4.5}, audit_context()
+        )
+
+
+@pytest.mark.asyncio
+async def test_replace_rule_is_atomic_and_replays_same_request() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+    client.seed("LimnopulseDomain", repository._rule_to_item(make_rule(rule_id="rule_old")))
+    replacement = make_rule(
+        rule_id="rule_new",
+        metric=AlertMetric.PH,
+        threshold=6.5,
+        replaces_rule_id="rule_old",
+    )
+
+    first = await repository.replace_rule(
+        "tnt_1",
+        "rule_old",
+        1,
+        replacement,
+        "replace-request-123",
+        "a" * 64,
+        audit_context(),
+    )
+    replay = await repository.replace_rule(
+        "tnt_1",
+        "rule_old",
+        1,
+        replacement,
+        "replace-request-123",
+        "a" * 64,
+        audit_context(),
+    )
+
+    assert replay == first
+    assert first.replaced.status == "replaced"
+    assert first.replaced.enabled is False
+    assert first.replaced.version == 2
+    assert first.replaced.replaced_by_rule_id == "rule_new"
+    assert first.replacement.replaces_rule_id == "rule_old"
+    assert len(client.transact_write_items_calls) == 1
+    transaction = client.transact_write_items_calls[0]["TransactItems"]
+    assert [set(operation) for operation in transaction] == [
+        {"Update"},
+        {"Put"},
+        {"Put"},
+        {"Put"},
+    ]
+    idempotency = decode_put(client, transaction[3])
+    assert idempotency["expires_at"] == int((NOW + timedelta(hours=24)).timestamp())
+    assert "replace-request-123" not in str(idempotency)
+
+
+@pytest.mark.asyncio
+async def test_replace_rule_rejects_idempotency_key_reuse_with_other_payload() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+    client.seed("LimnopulseDomain", repository._rule_to_item(make_rule(rule_id="rule_old")))
+    replacement = make_rule(rule_id="rule_new", replaces_rule_id="rule_old")
+    await repository.replace_rule(
+        "tnt_1",
+        "rule_old",
+        1,
+        replacement,
+        "replace-request-123",
+        "a" * 64,
+        audit_context(),
+    )
+
+    with pytest.raises(ConflictError):
+        await repository.replace_rule(
+            "tnt_1",
+            "rule_old",
+            1,
+            replacement,
+            "replace-request-123",
+            "b" * 64,
+            audit_context(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_expired_idempotency_record_does_not_block_replacement() -> None:
+    client = RecordingDynamoClient()
+    repository = make_repository(client)
+    client.seed("LimnopulseDomain", repository._rule_to_item(make_rule(rule_id="rule_old")))
+    idempotency_key = repository._idempotency_key("tnt_1", "replace-request-123")
+    client.seed(
+        "LimnopulseDomain",
+        {
+            **idempotency_key,
+            "entity_type": "idempotency",
+            "request_hash": "old",
+            "expires_at": int((NOW - timedelta(seconds=1)).timestamp()),
+        },
+    )
+
+    result = await repository.replace_rule(
+        "tnt_1",
+        "rule_old",
+        1,
+        make_rule(rule_id="rule_new", replaces_rule_id="rule_old"),
+        "replace-request-123",
+        "new",
+        audit_context(),
+    )
+
+    assert result.replacement.rule_id == "rule_new"

--- a/tests/unit/test_alert_rule_repository.py
+++ b/tests/unit/test_alert_rule_repository.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from botocore.exceptions import ClientError
 
 from limnopulse_api.adapters.alert_rules import DynamoAlertRuleRepository
 from limnopulse_api.core.errors import ConflictError, NotFoundError
@@ -45,9 +46,7 @@ class RecordingDynamoClient:
         items = [
             item
             for (table, pk, sk), item in self.items.items()
-            if table == table_name
-            and pk == values[":pk"]
-            and sk.startswith(values[":sk_prefix"])
+            if table == table_name and pk == values[":pk"] and sk.startswith(values[":sk_prefix"])
         ]
         items.sort(key=lambda item: item["SK"])
         return {"Items": [self._encode_item(item) for item in items]}
@@ -126,10 +125,7 @@ class RecordingDynamoClient:
         if isinstance(value, float):
             return Decimal(str(value))
         if isinstance(value, dict):
-            return {
-                key: self._normalize_for_dynamodb(item)
-                for key, item in value.items()
-            }
+            return {key: self._normalize_for_dynamodb(item) for key, item in value.items()}
         if isinstance(value, (list, tuple)):
             return [self._normalize_for_dynamodb(item) for item in value]
         return value
@@ -242,6 +238,29 @@ async def test_create_rule_maps_conditional_transaction_to_conflict() -> None:
 
     with pytest.raises(ConflictError):
         await repository.create_rule(make_rule(), audit_context())
+
+
+@pytest.mark.asyncio
+async def test_transaction_throttling_remains_an_infrastructure_error() -> None:
+    class ThrottledDynamoClient(RecordingDynamoClient):
+        def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "TransactionCanceledException",
+                        "Message": "transaction cancelled",
+                    },
+                    "CancellationReasons": [{"Code": "ThrottlingError"}],
+                },
+                "TransactWriteItems",
+            )
+
+    repository = make_repository(ThrottledDynamoClient())
+
+    with pytest.raises(ClientError) as captured:
+        await repository.create_rule(make_rule(), audit_context())
+
+    assert captured.value.response["CancellationReasons"] == [{"Code": "ThrottlingError"}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_init_dynamodb.py
+++ b/tests/unit/test_init_dynamodb.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+from scripts.dev.init_dynamodb import ensure_table
+
+
+class FakeWaiter:
+    def __init__(self, client: "FakeDynamoClient") -> None:
+        self.client = client
+
+    def wait(self, **kwargs: Any) -> None:
+        self.client.wait_calls.append(kwargs)
+
+
+class FakeDynamoClient:
+    def __init__(self, *, exists: bool, ttl_status: str = "DISABLED") -> None:
+        self.exists = exists
+        self.ttl_status = ttl_status
+        self.create_calls: list[dict[str, Any]] = []
+        self.wait_calls: list[dict[str, Any]] = []
+        self.describe_ttl_calls: list[dict[str, Any]] = []
+        self.update_ttl_calls: list[dict[str, Any]] = []
+
+    def list_tables(self) -> dict[str, list[str]]:
+        return {"TableNames": ["LimnopulseDomain"] if self.exists else []}
+
+    def create_table(self, **kwargs: Any) -> None:
+        self.create_calls.append(kwargs)
+
+    def get_waiter(self, name: str) -> FakeWaiter:
+        assert name == "table_exists"
+        return FakeWaiter(self)
+
+    def describe_time_to_live(self, **kwargs: Any) -> dict[str, Any]:
+        self.describe_ttl_calls.append(kwargs)
+        return {"TimeToLiveDescription": {"TimeToLiveStatus": self.ttl_status}}
+
+    def update_time_to_live(self, **kwargs: Any) -> None:
+        self.update_ttl_calls.append(kwargs)
+
+
+def expected_ttl_call() -> dict[str, Any]:
+    return {
+        "TableName": "LimnopulseDomain",
+        "TimeToLiveSpecification": {
+            "Enabled": True,
+            "AttributeName": "expires_at",
+        },
+    }
+
+
+def test_existing_local_table_has_ttl_enabled() -> None:
+    client = FakeDynamoClient(exists=True)
+
+    ensure_table(client, "LimnopulseDomain")
+
+    assert client.create_calls == []
+    assert client.describe_ttl_calls == [{"TableName": "LimnopulseDomain"}]
+    assert client.update_ttl_calls == [expected_ttl_call()]
+
+
+def test_new_local_table_is_created_before_ttl_is_enabled() -> None:
+    client = FakeDynamoClient(exists=False)
+
+    ensure_table(client, "LimnopulseDomain")
+
+    assert len(client.create_calls) == 1
+    assert client.wait_calls == [{"TableName": "LimnopulseDomain"}]
+    assert client.update_ttl_calls == [expected_ttl_call()]
+
+
+def test_already_enabled_ttl_is_left_unchanged() -> None:
+    client = FakeDynamoClient(exists=True, ttl_status="ENABLED")
+
+    ensure_table(client, "LimnopulseDomain")
+
+    assert client.describe_ttl_calls == [{"TableName": "LimnopulseDomain"}]
+    assert client.update_ttl_calls == []

--- a/tests/unit/test_opentofu_infra.py
+++ b/tests/unit/test_opentofu_infra.py
@@ -74,6 +74,9 @@ def test_cloud_dynamodb_tables_match_domain_contract() -> None:
     assert dynamodb.count('type = "S"') >= 4
     assert "point_in_time_recovery" in dynamodb
     assert "server_side_encryption" in dynamodb
+    assert dynamodb.count('attribute_name = "expires_at"') == 2
+    assert len(re.findall(r"ttl\s*\{", dynamodb)) == 2
+    assert len(re.findall(r'ttl\s*\{[^}]*enabled\s+=\s+true', dynamodb, re.DOTALL)) == 2
 
 
 def test_cognito_resources_export_application_environment_contract() -> None:

--- a/tests/unit/test_opentofu_infra.py
+++ b/tests/unit/test_opentofu_infra.py
@@ -12,9 +12,7 @@ def _read(relative_path: str) -> str:
 
 def _opentofu_text_files() -> list[Path]:
     return [
-        path
-        for path in TOFU_ROOT.rglob("*")
-        if path.is_file() and ".terraform" not in path.parts
+        path for path in TOFU_ROOT.rglob("*") if path.is_file() and ".terraform" not in path.parts
     ]
 
 
@@ -33,7 +31,11 @@ def test_opentofu_layout_documents_cloud_boundary() -> None:
         "versions.tf",
     }
 
-    assert {str(path.relative_to(TOFU_ROOT)).replace("\\", "/") for path in TOFU_ROOT.rglob("*") if path.is_file()} >= expected_files
+    assert {
+        str(path.relative_to(TOFU_ROOT)).replace("\\", "/")
+        for path in TOFU_ROOT.rglob("*")
+        if path.is_file()
+    } >= expected_files
 
     readme = _read("README.md")
     root_readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -76,7 +78,7 @@ def test_cloud_dynamodb_tables_match_domain_contract() -> None:
     assert "server_side_encryption" in dynamodb
     assert dynamodb.count('attribute_name = "expires_at"') == 2
     assert len(re.findall(r"ttl\s*\{", dynamodb)) == 2
-    assert len(re.findall(r'ttl\s*\{[^}]*enabled\s+=\s+true', dynamodb, re.DOTALL)) == 2
+    assert len(re.findall(r"ttl\s*\{[^}]*enabled\s+=\s+true", dynamodb, re.DOTALL)) == 2
 
 
 def test_cognito_resources_export_application_environment_contract() -> None:
@@ -86,12 +88,15 @@ def test_cognito_resources_export_application_environment_contract() -> None:
     assert 'resource "aws_cognito_user_pool" "main"' in cognito
     assert 'resource "aws_cognito_user_pool_client" "api"' in cognito
     assert 'auto_verified_attributes = ["email"]' in cognito
-    assert 'generate_secret = false' in cognito
+    assert "generate_secret = false" in cognito
     assert '"ALLOW_USER_SRP_AUTH"' in cognito
     assert 'output "cognito_user_pool_id"' in outputs
     assert 'output "cognito_client_id"' in outputs
     assert 'output "cognito_issuer"' in outputs
-    assert 'https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}' in outputs
+    assert (
+        "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}"
+        in outputs
+    )
     assert "Cloud Redis endpoint placeholder only" in outputs
     assert "Cloud InfluxDB endpoint placeholder only" in outputs
 


### PR DESCRIPTION
## Summary

- add tenant-scoped Alert Rule list, create, PATCH, and idempotent replace endpoints
- enforce role authorization, strict payload validation, immutable semantic identity, target pond/device validation, and optimistic versions
- add a focused DynamoDB repository using Query and atomic cross-table audit transactions
- persist 24-hour replacement replay records and 90-day audit records with application-aware TTL semantics
- enable `expires_at` TTL in OpenTofu and local DynamoDB initialization
- document the canonical Limnopulse architecture and the Phase 3A/3B/3C boundaries

## Why

Phase 3A establishes the configuration and consistency boundary needed before the Go evaluator and notification dispatcher are built. Alert Rule identity changes use replacement instead of in-place mutation so rule history and future event evaluation remain traceable.

## API impact

- `GET /v1/tenants/{tenant_id}/alert-rules` — all active tenant roles
- `POST /v1/tenants/{tenant_id}/alert-rules` — owner/admin
- `PATCH /v1/tenants/{tenant_id}/alert-rules/{rule_id}` — owner/admin
- `POST /v1/tenants/{tenant_id}/alert-rules/{rule_id}/replace` — owner/admin with `Idempotency-Key`

This PR intentionally excludes Alert Events, telemetry evaluation, Redis cooldown/deduplication, SQS dispatch, SES, and Telegram delivery.

## Consistency and security

- rule lists use DynamoDB `Query`; application code does not use `Scan`
- create/update/replace mutations write audit records atomically
- stale versions and idempotency payload conflicts return `409`
- throttling/capacity transaction cancellations remain infrastructure errors
- replay results remain valid even if the target changes after the original request
- audit records store hashes and request metadata, not JWTs, credentials, or mutation payloads
- raw idempotency keys are not persisted

## Validation

- `uv run --extra dev --python 3.12 python -m pytest -q` — 133 passed
- `uv run --extra dev --python 3.12 python -m compileall -q src tests scripts`
- Ruff check and format verification for all changed Python files
- `docker compose config --quiet`
- `tofu -chdir=infra/opentofu fmt -check`
- `tofu -chdir=infra/opentofu init -backend=false`
- `tofu -chdir=infra/opentofu validate`
- `git diff --check origin/main...HEAD`
