### PR TITLE
docs(plan): add LimnoPulse production implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-08-31-limnopulse-production-application-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-31-limnopulse-production-application-implementation-plan.md
@@ -1,0 +1,572 @@
+# LimnoPulse Production Application Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the portfolio-demo application release: a deterministic static frontend, a fail-closed FastAPI image, one-shot evaluator and synthetic publisher images, authenticated internal MQTT/Telegraf ingestion, production Compose, deterministic demo seed and credential-renewal-safe runtime.
+
+**Architecture:** Preserve all existing V4 and /v1 domain contracts while adding a production-only composition that omits commercial, cache and notification/delivery capabilities completely. The browser authenticates through Cognito and reads only synthetic demo data. API, InfluxDB, Mosquitto and Telegraf run in isolated containers; evaluator and publisher are one-shot jobs invoked externally.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic Settings, boto3, InfluxDB client, Go 1.26, React 18, TypeScript, Vite, oidc-client-ts, Vitest, Playwright, Docker/Compose, Mosquitto 2, Telegraf, pytest.
+
+**Spec:** docs/superpowers/specs/2026-08-29-limnopulse-production-deployment-design.md
+
+## Global Constraints
+
+- Start only after every P0/M1 task in docs/superpowers/plans/2026-08-25-limnopulse-v4-p0-m1.md is merged and its M1-08 gate is green on main. This plan consumes that work and does not recreate it.
+- The inspected planning baseline is main@e95d3eee9c813e3946d43f297071a80b62dd123b and lacks frontend, production API image and GitHub workflows. Re-read the head and record the exact execution baseline in each PR.
+- Production uses APP_ENV=prod, AUTH_MODE=cognito and AWS_REGION=us-east-2.
+- The portfolio-demo profile creates no Redis or Telegram client, route, secret verifier, worker or schedule. It also creates no Stripe, SES, Push, SMS, AWS IoT, vendor connector or command component.
+- Disabled is structural absence, not a fake sender or UI-only feature flag.
+- Production rejects DynamoDB/SQS/Cognito endpoint overrides and any external Influx URL. Only http://influxdb:8086 is allowed.
+- Ordinary membership reads operate directly against DynamoDB when caching is disabled.
+- CORS is exactly https://limnopulse.com; methods GET, POST, PUT, PATCH, DELETE, OPTIONS; headers Authorization, Content-Type, Idempotency-Key; allow_credentials=false; no wildcard.
+- Frontend runtime configuration is public and contains only API/Cognito/release/capability values.
+- Static output is deterministic under web/dist and registers no service worker.
+- Compose production does not extend compose.yaml and contains no emulator, local AWS key, fake provider, source build or mutable image tag.
+- API is the only loopback-published product port. InfluxDB and MQTT have no host port.
+- Mosquitto uses distinct publisher and Telegraf principals with default-deny ACLs.
+- Images and base images are pinned by digest at release integration. Mutable tags may appear only in a documented local-development target.
+- Test names in new Python tests describe behavior in Portuguese where the current repository convention requires it.
+- One task/branch/PR at a time unless the execution graph explicitly permits parallel work.
+
+## File Map
+
+| Path | Responsibility |
+|---|---|
+| src/limnopulse_api/core/production.py | portfolio-demo invariant validation |
+| src/limnopulse_api/composition.py | explicit dev/full versus portfolio composition |
+| src/limnopulse_api/api/production_router.py | production-safe route selection |
+| src/limnopulse_api/observability.py | redacted JSON logging |
+| Dockerfile.api | pinned non-root API image |
+| cmd/synthetic-publisher/** | one-shot synthetic MQTT producer |
+| Dockerfile.synthetic-publisher | publisher image |
+| web/** | versioned static product frontend |
+| compose.production.yaml | production-only services/jobs |
+| infra/mqtt/production/** | Mosquitto password/ACL templates |
+| infra/telegraf/production/** | trusted registry and ingestion configuration |
+| scripts/production/seed_demo.py | idempotent tenant/user-facing domain seed |
+| tests/production/** | production contract and acceptance tests |
+
+---
+
+### Task 1: Enforce the V4 M1 Dependency Gate
+
+**Branch:** test/prod-001-v4-gate
+
+**Files:**
+- Create: tests/production/test_v4_dependency_gate.py
+- Create: docs/production-readiness.md
+
+**Interfaces:**
+- Consumes the M1-08 acceptance test, feature flags and migration runbook.
+- Produces no runtime behavior.
+
+- [ ] **Step 1: Write the failing dependency inventory**
+
+    REQUIRED = (
+        "tests/contracts/test_m1_acceptance_gate.py",
+        "docs/m1-acceptance-runbook.md",
+        "src/limnopulse_api/api/v2/router.py",
+    )
+
+    def test_dependencias_v4_m1_estao_integradas() -> None:
+        for relative in REQUIRED:
+            assert (ROOT / relative).is_file(), relative
+
+- [ ] **Step 2: Run the test on the current baseline**
+
+    uv run --locked --extra dev pytest -q tests/production/test_v4_dependency_gate.py
+
+Expected on the inspected baseline: FAIL. Stop execution of Tasks 2-12 until M1-08 is merged; do not make this test skip or xfail.
+
+- [ ] **Step 3: Document the exact green SHA and commands after integration**
+
+Record make verify, M1 acceptance and /v1 golden results in docs/production-readiness.md.
+
+- [ ] **Step 4: Commit only after the dependency is genuinely green**
+
+    git add tests/production/test_v4_dependency_gate.py docs/production-readiness.md
+    git commit -m "test(prod): require integrated V4 M1 baseline"
+
+### Task 2: Add the Fail-Closed Portfolio Settings Contract
+
+**Branch:** feat/prod-002-settings
+
+**Files:**
+- Modify: src/limnopulse_api/core/config.py
+- Create: src/limnopulse_api/core/production.py
+- Modify: .env.example
+- Create: tests/production/test_portfolio_settings.py
+- Modify: tests/unit/test_settings.py
+
+**Interfaces:**
+- Adds deployment_profile: Literal["development", "portfolio-demo"].
+- Adds cache_enabled and outbound feature flags, all false in portfolio-demo.
+- validate_portfolio_demo(settings) rejects forbidden settings and endpoints.
+
+- [ ] **Step 1: Write failing settings tests**
+
+    def test_portfolio_demo_exige_prod_cognito_e_us_east_2() -> None:
+        settings = portfolio_settings()
+        assert settings.app_env == "prod"
+        assert settings.auth_mode == "cognito"
+        assert settings.aws_region == "us-east-2"
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"redis_enabled": True},
+            {"telegram_delivery_enabled": True},
+            {"dynamodb_endpoint_url": "http://dynamodb-local:8000"},
+            {"influxdb_url": "https://external.example"},
+        ],
+    )
+    def test_portfolio_demo_rejeita_recurso_proibido(override) -> None:
+        with pytest.raises(ValidationError):
+            Settings(**portfolio_values(), **override)
+
+- [ ] **Step 2: Run and verify RED**
+
+- [ ] **Step 3: Add explicit fields and a single production validator**
+
+Use positive enable flags with false defaults. The portfolio validator requires all disabled features false, no endpoint override, no direct Telegram secret/ARN/username dependency and exact internal Influx URL.
+
+- [ ] **Step 4: Preserve current local/test behavior**
+
+All existing test fixtures using Settings(app_env="test", auth_mode="dev") remain valid. Do not make portfolio-demo the default.
+
+- [ ] **Step 5: Run settings suites and commit**
+
+    uv run --locked --extra dev pytest -q tests/unit/test_settings.py tests/production/test_portfolio_settings.py
+    git add src/limnopulse_api/core .env.example tests
+    git commit -m "feat(prod): add fail-closed portfolio settings"
+
+### Task 3: Split Application Composition and Omit Disabled Features
+
+**Branch:** feat/prod-003-composition
+
+**Files:**
+- Create: src/limnopulse_api/composition.py
+- Create: src/limnopulse_api/api/production_router.py
+- Modify: src/limnopulse_api/main.py
+- Modify: src/limnopulse_api/services/memberships.py
+- Create: tests/production/test_portfolio_composition.py
+- Modify: tests/api/test_app_runtime.py
+
+**Interfaces:**
+- build_runtime(settings) returns a context-managed RuntimeComponents.
+- portfolio runtime contains DynamoDB, Cognito, Influx and NoCache only.
+- build_production_router excludes Telegram webhook/bindings and notification preferences.
+
+- [ ] **Step 1: Write tests that make forbidden constructors explode**
+
+Patch redis.from_url, boto3 secretsmanager, Telegram services and notification repositories to raise AssertionError. Start TestClient with portfolio settings and assert health, membership-backed routes and telemetry read initialize successfully.
+
+- [ ] **Step 2: Assert forbidden OpenAPI paths are absent**
+
+    def test_portfolio_nao_expoe_rotas_desabilitadas() -> None:
+        paths = create_app(portfolio_settings()).openapi()["paths"]
+        assert not any("telegram" in path for path in paths)
+        assert not any("notification-preferences" in path for path in paths)
+
+- [ ] **Step 3: Implement NoCache at the repository boundary**
+
+NoCache returns cache misses and no-op writes without creating/probing Redis. MembershipService still fetches canonical DynamoDB rows on every ordinary read.
+
+- [ ] **Step 4: Move construction out of the lifespan hotspot**
+
+Keep create_app deterministic. Local/default composition preserves all current behavior. Portfolio production router includes health, me, tenants, ponds/sites, devices, telemetry, alert rules/events and approved M1 routes only.
+
+- [ ] **Step 5: Run current and production runtime suites**
+
+    uv run --locked --extra dev pytest -q tests/api/test_app_runtime.py tests/production/test_portfolio_composition.py tests/unit/test_membership_cache.py
+
+- [ ] **Step 6: Commit**
+
+    git add src/limnopulse_api tests
+    git commit -m "feat(prod): compose portfolio without cache or delivery"
+
+### Task 4: Add Exact CORS, Health and Redacted JSON Logs
+
+**Branch:** feat/prod-004-http-observability
+
+**Files:**
+- Modify: src/limnopulse_api/main.py
+- Create: src/limnopulse_api/observability.py
+- Modify: src/limnopulse_api/api/v1/routers/health.py
+- Create: tests/production/test_cors.py
+- Create: tests/production/test_health.py
+- Create: tests/production/test_json_logging.py
+
+**Interfaces:**
+- GET /health/live does process-only liveness.
+- GET /health/ready performs bounded DynamoDB and Influx checks without details.
+- JSON logs redact Authorization, cookies, tokens, emails, payload bodies and high-cardinality IDs.
+
+- [ ] **Step 1: Write the exact preflight matrix**
+
+Allowed origin/method/header combinations return expected CORS headers. Another origin, wildcard, cookies and an unlisted header do not receive an allow response.
+
+- [ ] **Step 2: Write independent health tests**
+
+Liveness remains 200 during dependency failure; readiness returns 503 with only {"status":"unavailable"} and a request ID header.
+
+- [ ] **Step 3: Implement CORSMiddleware only for portfolio**
+
+Use the literal arrays from the Spec and allow_credentials=False. Local composition remains independently configurable for tests.
+
+- [ ] **Step 4: Implement one-line redacted JSON formatter**
+
+Fields are timestamp, level, service, event, request_id and bounded outcome. A recursive sanitizer rejects known secret keys and URL query strings.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_cors.py tests/production/test_health.py tests/production/test_json_logging.py
+    git add src/limnopulse_api tests/production
+    git commit -m "feat(prod): add exact cors health and redacted logs"
+
+### Task 5: Build the Non-Root API Image
+
+**Branch:** feat/prod-005-api-image
+
+**Files:**
+- Create: Dockerfile.api
+- Create: docker/api/entrypoint.sh
+- Create: docker/api/healthcheck.py
+- Create: .dockerignore additions
+- Create: tests/production/test_api_image.py
+
+**Interfaces:**
+- Image runs a fixed UID/GID, execs uvicorn and exposes 8000 only as metadata.
+- Runtime requires external read-only credential/config and secret files.
+
+- [ ] **Step 1: Write a Dockerfile policy test**
+
+Require multi-stage, lock-respecting dependency install, numeric USER, no shell package in final stage, HEALTHCHECK, no COPY . and no embedded .env/key.
+
+- [ ] **Step 2: Build and inspect the candidate image**
+
+    docker build --pull --tag limnopulse-api:test --file Dockerfile.api .
+    docker image inspect limnopulse-api:test
+
+Expected before implementation: Dockerfile missing.
+
+- [ ] **Step 3: Implement pinned multi-stage build**
+
+Copy pyproject/lock first, install locked wheel/runtime dependencies, copy src only, use a minimal digest-pinned Python runtime and set PYTHONDONTWRITEBYTECODE/PYTHONUNBUFFERED.
+
+- [ ] **Step 4: Run container security smoke**
+
+Start with read-only root, tmpfs /tmp, cap-drop ALL, no-new-privileges and portfolio env fixtures. Assert UID nonzero, / write fails and live endpoint passes.
+
+- [ ] **Step 5: Commit**
+
+    git add Dockerfile.api docker/api .dockerignore tests/production/test_api_image.py
+    git commit -m "feat(prod): add hardened api image"
+
+### Task 6: Create the Static Portfolio Frontend
+
+**Branch:** feat/prod-006-frontend-foundation
+
+**Files:**
+- Create: web/package.json
+- Create: web/package-lock.json
+- Create: web/tsconfig.json
+- Create: web/vite.config.ts
+- Create: web/index.html
+- Create: web/src/main.tsx
+- Create: web/src/App.tsx
+- Create: web/src/config.ts
+- Create: web/src/styles.css
+- Create: web/src/sw-guard.ts
+- Create: web/tests/config.test.ts
+- Create: web/tests/build.test.ts
+- Create: web/public/runtime-config.example.json
+
+**Interfaces:**
+- RuntimeConfig contains apiBaseUrl, cognitoIssuer, cognitoClientId, cognitoAuthorizationBaseUrl, awsRegion, releaseId and capabilities.
+- Production apiBaseUrl is https://api.limnopulse.com/v1.
+- Output is web/dist and contains no service worker.
+
+- [ ] **Step 1: Write failing runtime-config validation tests**
+
+Reject missing release, non-HTTPS API, wrong API origin, secret-like fields, unknown capabilities and production URLs outside the approved domains.
+
+- [ ] **Step 2: Scaffold a locked React/Vite build**
+
+Pin exact dependencies and Node version. Scripts are lint, typecheck, test and build. Do not add analytics, external fonts or third-party scripts.
+
+- [ ] **Step 3: Implement a minimal honest portfolio surface**
+
+Pages: public overview explaining synthetic/demo scope, sign-in callback, authenticated dashboard with tenant selector, synthetic telemetry and alert state. Clearly label every measurement as synthetic.
+
+- [ ] **Step 4: Add deterministic build metadata**
+
+SOURCE_DATE_EPOCH and release ID drive stable output. Hash assets; runtime config and index are release-coupled inputs. sw-guard fails if navigator.serviceWorker.register, service-worker filenames or Workbox appear.
+
+- [ ] **Step 5: Run frontend gates**
+
+    npm --prefix web ci
+    npm --prefix web run lint
+    npm --prefix web run typecheck
+    npm --prefix web test -- --run
+    npm --prefix web run build
+
+- [ ] **Step 6: Commit**
+
+    git add web
+    git commit -m "feat(web): add deterministic portfolio frontend"
+
+### Task 7: Implement Cognito PKCE and the Authenticated API Client
+
+**Branch:** feat/prod-007-frontend-auth
+
+**Files:**
+- Create: web/src/auth/oidc.ts
+- Create: web/src/auth/AuthProvider.tsx
+- Create: web/src/api/client.ts
+- Create: web/src/api/queries.ts
+- Create: web/src/routes/**
+- Create: web/tests/auth.test.tsx
+- Create: web/tests/client.test.ts
+- Create: web/tests/e2e/portfolio.spec.ts
+
+**Interfaces:**
+- Public Authorization Code + PKCE, no client secret and in-memory tokens.
+- API client sends bearer only to api.limnopulse.com and tenant identity only after membership selection.
+- No delivery/notification mutation exists.
+
+- [ ] **Step 1: Write token-leak and origin tests**
+
+Reject localStorage/sessionStorage tokens, Authorization to another origin, cookies/credentials and tenant IDs supplied before canonical membership selection.
+
+- [ ] **Step 2: Implement OIDC manager from runtime config**
+
+Issuer/client/authorization base must agree and use HTTPS. Callback/logout are exact limnopulse.com URLs. Scope is openid email profile.
+
+- [ ] **Step 3: Implement one typed fetch boundary**
+
+credentials="omit"; mode="cors"; Authorization set only after URL origin comparison; Idempotency-Key only on approved mutations; errors never serialize response headers containing secrets.
+
+- [ ] **Step 4: Implement synthetic dashboard queries**
+
+Use existing /v1 me, tenants, ponds/sites, devices, telemetry and alert endpoints. Display a capability-disabled explanation instead of notification controls.
+
+- [ ] **Step 5: Run unit/E2E/build and commit**
+
+    npm --prefix web test -- --run
+    npm --prefix web run build
+    npm --prefix web exec playwright test
+    git add web
+    git commit -m "feat(web): add cognito login and safe api client"
+
+### Task 8: Add the One-Shot Synthetic Publisher
+
+**Branch:** feat/prod-008-synthetic-publisher
+
+**Files:**
+- Create: cmd/synthetic-publisher/main.go
+- Create: internal/synthetic/config.go
+- Create: internal/synthetic/fixture.go
+- Create: internal/synthetic/publisher.go
+- Create: internal/synthetic/*_test.go
+- Create: fixtures/synthetic/v1.json
+- Create: Dockerfile.synthetic-publisher
+
+**Interfaces:**
+- Command run publishes exactly one versioned fixture to the exact synthetic topic prefix and exits.
+- Payload contains device measurement identity/value/time only; tenant/site enrichment comes from trusted Telegraf registry.
+- Exit codes distinguish success, retryable dependency failure and terminal configuration failure.
+
+- [ ] **Step 1: Write Go tests for fixture determinism and topic restriction**
+
+- [ ] **Step 2: Write tests that reject tenant/site fields and arbitrary topics**
+
+- [ ] **Step 3: Implement strict config and one-shot publish**
+
+Require APP_ENV=prod, broker service name, client ID, username/password file and exact topic. Bound connect/publish timeout and message size.
+
+- [ ] **Step 4: Build a distroless non-root image**
+
+Pin builder/runtime digests during integration. No shell, certificate private key or AWS credential is needed.
+
+- [ ] **Step 5: Run and commit**
+
+    go test -race ./...
+    docker build --tag limnopulse-synthetic:test --file Dockerfile.synthetic-publisher .
+    git add cmd/synthetic-publisher internal/synthetic fixtures/synthetic Dockerfile.synthetic-publisher
+    git commit -m "feat(synthetic): add one-shot mqtt publisher"
+
+### Task 9: Harden MQTT and Telegraf Production Ingestion
+
+**Branch:** feat/prod-009-mqtt-telegraf
+
+**Files:**
+- Create: infra/mqtt/production/mosquitto.conf
+- Create: infra/mqtt/production/acl.template
+- Create: infra/mqtt/production/password-file.README
+- Create: infra/telegraf/production/telegraf.conf
+- Create: infra/telegraf/production/device_registry.star
+- Create: tests/production/test_mqtt_telegraf.py
+- Create: tests/production/mqtt_matrix.sh
+
+**Interfaces:**
+- Principal synthetic-publisher can write only the exact topic and cannot read/subscribe.
+- Principal telegraf can read/subscribe only that topic and cannot write.
+- Anonymous/other topics are denied; unknown device is dropped and counted.
+
+- [ ] **Step 1: Write static configuration tests**
+
+Require allow_anonymous false, no listener host binding, password_file and acl_file. Reject pattern ACLs broader than the exact synthetic prefix.
+
+- [ ] **Step 2: Create a two-principal integration matrix**
+
+Test allowed publisher->Telegraf flow and every denied cross-operation with generated fixture passwords.
+
+- [ ] **Step 3: Implement production configurations**
+
+Secrets are file paths, not environment values. Starlark registry maps only the deterministic demo device to bounded tenant/site tags and increments unknown-device metric without payload log.
+
+- [ ] **Step 4: Run broker/Telegraf integration**
+
+    docker compose -f tests/production/mqtt-compose.yml up --abort-on-container-exit --exit-code-from verifier
+    docker compose -f tests/production/mqtt-compose.yml down -v --remove-orphans
+
+- [ ] **Step 5: Commit**
+
+    git add infra/mqtt/production infra/telegraf/production tests/production
+    git commit -m "feat(ingestion): isolate synthetic mqtt principals"
+
+### Task 10: Create Independent Production Compose
+
+**Branch:** feat/prod-010-compose
+
+**Files:**
+- Create: compose.production.yaml
+- Create: config/production/api.env.schema
+- Create: config/production/evaluator.env.schema
+- Create: config/production/publisher.env.schema
+- Create: tests/production/test_compose_contract.py
+
+**Interfaces:**
+- Long-lived services: api, influxdb, mqtt, telegraf.
+- One-shot profiles: evaluator, synthetic-publisher, backup-verify.
+- API binds one declared loopback port; all other services are internal only.
+
+- [ ] **Step 1: Write a structural policy test**
+
+Reject extends/include of compose.yaml, build, latest/mutable images, emulator names, Redis, notification workers, host network, privileged, docker.sock, public ports and local AWS keys.
+
+- [ ] **Step 2: Add resource/security assertions**
+
+Every service uses read_only where supported, cap_drop ALL, no-new-privileges, non-root user, pids/memory/cpu/log limits, healthcheck and product-specific networks.
+
+- [ ] **Step 3: Implement Compose with digest variables**
+
+Require API_IMAGE, EVALUATOR_IMAGE and SYNTHETIC_PUBLISHER_IMAGE matching @sha256. Mount /run/personal-platform/limnopulse/aws as a directory read-only into API/evaluator only. Mount separate MQTT password files to their owners.
+
+- [ ] **Step 4: Keep Influx persistence outside releases**
+
+Named external volume limnopulse-influxdb-prod. Initialization token is visible only to init/backup boundary; API receives application token file.
+
+- [ ] **Step 5: Validate and commit**
+
+    docker compose -f compose.production.yaml config --quiet
+    uv run --locked --extra dev pytest -q tests/production/test_compose_contract.py
+    git add compose.production.yaml config/production tests/production/test_compose_contract.py
+    git commit -m "feat(prod): add isolated production compose"
+
+### Task 11: Add Idempotent Demo Seed and First-Breach Fixture
+
+**Branch:** feat/prod-011-demo-seed
+
+**Files:**
+- Create: scripts/production/seed_demo.py
+- Create: src/limnopulse_api/seed/demo.py
+- Create: tests/production/test_demo_seed.py
+- Create: docs/demo-data.md
+
+**Interfaces:**
+- seed_demo creates one reviewed tenant, site/pond, synthetic device, memberships and one deterministic active due alert rule.
+- Re-run returns existing matching records; divergent ownership/content fails.
+- Cognito user password/message handling is not in this script.
+
+- [ ] **Step 1: Write idempotency and collision tests**
+
+Run twice and assert identical IDs/versions with zero second writes. Existing non-demo tenant or user-authored rule at the deterministic key yields conflict and no overwrite.
+
+- [ ] **Step 2: Write first-breach timing tests**
+
+The one-minute rule and fixture create a sufficient complete window, due no later than the smoke time, and open the expected incident on first evaluation.
+
+- [ ] **Step 3: Implement conditional DynamoDB writes**
+
+Use TransactWriteItems/condition expressions and canonical key helpers. Never Scan or bulk delete.
+
+- [ ] **Step 4: Add visibly synthetic labels**
+
+Names and descriptions include “Demonstração — dados sintéticos”; docs prohibit municipal/customer data.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_demo_seed.py tests/unit/test_no_scan_guard.py
+    git add scripts/production src/limnopulse_api/seed tests/production/test_demo_seed.py docs/demo-data.md
+    git commit -m "feat(prod): seed deterministic synthetic demo"
+
+### Task 12: Build the Local Production Acceptance Gate
+
+**Branch:** test/prod-012-application-acceptance
+
+**Files:**
+- Create: tests/production/test_application_acceptance.py
+- Create: tests/production/smoke.sh
+- Create: docs/runbooks/application-smoke.md
+- Modify: Makefile
+
+**Interfaces:**
+- Produces make verify-production-application.
+- No AWS, Cloudflare, SSH or production credential is required.
+
+- [ ] **Step 1: Add the aggregate contract**
+
+Require V4 M1 green; portfolio app starts with forbidden constructors patched; exact CORS; image policies; web build; no service worker; Compose schema; MQTT ACL; seed idempotency; synthetic publisher/evaluator flow.
+
+- [ ] **Step 2: Add credential-renewal rehearsal hooks**
+
+Mount a fake credential directory, start API, atomically replace it, invoke the fixed graceful replacement hook expected from infra-ansible, and prove the new process uses the new identity while the old drains.
+
+- [ ] **Step 3: Run all local gates**
+
+    make verify
+    make verify-production-application
+    docker compose -f compose.production.yaml config --quiet
+    git diff --check
+
+- [ ] **Step 4: Scan the exact release inputs**
+
+    git grep -nEi '(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|TELEGRAM_BOT_TOKEN|local-dev-token)' -- compose.production.yaml config/production web/dist
+
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+    git add tests/production docs/runbooks/application-smoke.md Makefile
+    git commit -m "test(prod): add portfolio application acceptance gate"
+
+## Execution Order
+
+Task 1 is a hard serial gate. Tasks 2 and 6 may start after it. Task 3 waits for Task 2; Task 4 waits for Task 3. Task 5 waits for Tasks 2-4. Task 7 waits for Task 6. Tasks 8 and 9 may proceed after Task 1 and join before Task 10. Task 10 waits for Tasks 5, 8 and 9. Task 11 waits for Task 3 plus the M1 adapters. Task 12 waits for every prior task.
+
+## Plan Self-Review Record
+
+- V4 relationship: M1 remains the dependency; no M1 entity, adapter or migration is duplicated.
+- Disabled features: every forbidden constructor, route, secret and Compose service has a negative test.
+- Frontend: deterministic product code, exact public runtime schema, no service worker or secret.
+- Runtime: exact prod/Cognito/us-east-2 contract, direct DynamoDB membership, internal Influx only.
+- Ingestion: separate MQTT principals, trusted enrichment and unknown-device drop.
+- Data safety: deterministic synthetic-only seed with conditional collision behavior.
+- Completeness scan: no unresolved marker, fake-success provider or undefined startup behavior.
+
+## Execution Handoff
+
+Implement in worktree PRs after M1-08 is green. This plan ends with locally verifiable release inputs; AWS resources, release manifests, systemd timers and production promotion belong to the companion delivery plan.

--- a/docs/superpowers/plans/2026-08-31-limnopulse-production-infrastructure-and-delivery-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-31-limnopulse-production-infrastructure-and-delivery-implementation-plan.md
@@ -1,0 +1,512 @@
+# LimnoPulse Production Infrastructure and Delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision and safely promote the LimnoPulse portfolio-demo AWS resources and immutable application release through GitHub-hosted CI, private S3/CloudFront, Cognito, DynamoDB, base SQS/DLQ, least-privilege IAM and the shared personal VPS delivery gate.
+
+**Architecture:** Product OpenTofu owns only LimnoPulse AWS resources and exports narrow edge contracts. Pull requests validate without credentials. Manual plan/apply and host promotion call immutable reusable gates in personal-infra-live through GitHub OIDC. Static releases use immutable prefixes and a last-write root index; API and one-shot jobs use digest-bound Compose on the VPS.
+
+**Tech Stack:** OpenTofu 1.8+, AWS provider, AWS us-east-2, ACM/WAF/Pricing Plan Manager us-east-1, S3, CloudFront/OAC, Cognito, DynamoDB, SQS/DLQ, CloudWatch, IAM, GitHub Actions, GHCR, Syft, Trivy, OPA/Conftest, pytest.
+
+**Spec:** docs/superpowers/specs/2026-08-29-limnopulse-production-deployment-design.md
+
+## Global Constraints
+
+- Start only after the companion application plan is merged and make verify-production-application is green on main.
+- Shared state/KMS/SSM/Budgets/OIDC/Roles Anywhere, Cloudflare and VPS resources are references from personal-infra-live; this state never recreates them.
+- Primary provider is us-east-2. Alias global_edge in us-east-1 owns only ACM certificate and CLOUDFRONT-scope WAF.
+- State key is limnopulse/prod/opentofu.tfstate in the private shared backend with use_lockfile=true.
+- OpenTofu backend bucket/account IDs, Cloudflare IDs and state never appear in this public repository.
+- core_dynamodb, core_cognito and core_sqs are true in portfolio-demo. Every commercial/notification/device provider flag is false and creates zero resources, IAM statements, secret containers or outputs.
+- The exact managed Cognito domain prefix is limnopulse-portfolio-demo. Unavailability fails planning/rollout; do not invent a suffix.
+- DynamoDB is PAY_PER_REQUEST with PITR 35 days and maximum throughput 100 reads/25 writes on tables and every GSI.
+- The base notification queue/DLQ exists, but relay/provider scheduling and delivery workers do not.
+- Static S3 is private and versioned; CloudFront uses OAC and one dedicated WAF. No S3 website endpoint.
+- CloudFront Free is a separate manual idempotent Pricing Plan Manager step and must be ACTIVE before DNS. No local-exec and no paid fallback.
+- LimnoPulse managed-service envelope is USD 3; aggregate automation freeze remains USD 15.
+- GitHub Actions paid spending is USD 0; no self-hosted runner or production credential on pull requests.
+- Merge never deploys. Apply and promotion are workflow_dispatch with exact expiring evidence.
+
+## File Map
+
+| Path | Responsibility |
+|---|---|
+| infra/opentofu/modules/core-* | enabled DynamoDB/Cognito/SQS |
+| infra/opentofu/modules/static-web | S3/CloudFront/OAC/ACM/WAF |
+| infra/opentofu/modules/runtime-iam | VPS/job/canary least privilege |
+| infra/opentofu/modules/observability | bounded alarms/log retention |
+| infra/opentofu/env/prod | product composition and outputs |
+| policies | cost/resource/secret/ownership policy |
+| release | manifest schemas and builders |
+| .github/workflows | validation, release, plan/apply and promotion callers |
+| scripts/deploy | static, Free-plan, canary, promotion and rollback helpers |
+| docs/runbooks | manual operations and acceptance |
+
+---
+
+### Task 1: Refactor OpenTofu into Explicit Feature Modules
+
+**Branch:** feat/prod-infra-001-feature-boundaries
+
+**Files:**
+- Create: infra/opentofu/modules/core-dynamodb/**
+- Create: infra/opentofu/modules/core-cognito/**
+- Create: infra/opentofu/modules/core-sqs/**
+- Create: infra/opentofu/modules/email-delivery/**
+- Create: infra/opentofu/modules/telegram-delivery/**
+- Modify: infra/opentofu/*.tf
+- Create: infra/opentofu/env/prod/main.tf
+- Create: infra/opentofu/env/prod/variables.tf
+- Create: infra/opentofu/env/prod/outputs.tf
+- Create: tests/production/test_opentofu_feature_boundaries.py
+
+**Interfaces:**
+- Feature object contains core_dynamodb/core_cognito/core_sqs and all disabled flags from the Spec.
+- count/for_each is applied at module boundary; disabled modules have zero resources and outputs.
+
+- [ ] **Step 1: Write a plan-JSON fixture test**
+
+With portfolio variables, assert there is no SES, EventBridge custom bus, Telegram Secrets Manager, Push/SMS, Stripe, IoT or Redis resource/address.
+
+- [ ] **Step 2: Run current OpenTofu tests and confirm unconditional resources fail**
+
+    uv run --locked --extra dev pytest -q tests/unit/test_opentofu_infra.py tests/production/test_opentofu_feature_boundaries.py
+
+- [ ] **Step 3: Move existing resources without changing enabled semantics**
+
+First preserve current cloud example with explicit true flags; then compose portfolio-demo with only core modules. Use moved blocks where state address migration is needed and test the mapping.
+
+- [ ] **Step 4: Add validations that reject forbidden portfolio flags**
+
+- [ ] **Step 5: Validate and commit**
+
+    tofu -chdir=infra/opentofu init -backend=false -input=false
+    tofu -chdir=infra/opentofu fmt -check -recursive
+    tofu -chdir=infra/opentofu validate -no-color
+    uv run --locked --extra dev pytest -q tests/unit/test_opentofu_infra.py tests/production/test_opentofu_feature_boundaries.py
+    git add infra/opentofu tests
+    git commit -m "refactor(infra): isolate production feature modules"
+
+### Task 2: Harden DynamoDB and Base SQS/DLQ
+
+**Branch:** feat/prod-infra-002-data-queues
+
+**Files:**
+- Modify: infra/opentofu/modules/core-dynamodb/**
+- Modify: infra/opentofu/modules/core-sqs/**
+- Create: tests/production/test_data_queue_plan.py
+
+**Interfaces:**
+- Tables LimnopulseDomain and LimnopulseAudit retain approved keys/indexes.
+- Base queue uses long polling, encryption, bounded retention/visibility and DLQ redrive.
+- Canary policy accepts a non-domain schema and cannot mutate NotificationDelivery.
+
+- [ ] **Step 1: Write plan assertions for table controls**
+
+Require PAY_PER_REQUEST, PITR, TTL, deletion protection, 100/25 maximum throughput, encryption and no global replicas/Contributor Insights/autoscaling.
+
+- [ ] **Step 2: Write queue boundary tests**
+
+Require one base queue plus DLQ only; absent email/Telegram provider queues; redrive maxReceiveCount; no public policy.
+
+- [ ] **Step 3: Implement resources and least-privilege canary role**
+
+The canary role can send/receive/delete only explicit canary bodies and has no DynamoDB delivery mutation.
+
+- [ ] **Step 4: Validate with local queue contract**
+
+    uv run --locked --extra dev pytest -q tests/production/test_data_queue_plan.py tests/integration/test_notifications_local.py
+
+- [ ] **Step 5: Commit**
+
+    git add infra/opentofu/modules tests/production/test_data_queue_plan.py
+    git commit -m "feat(infra): harden demo tables and base queue"
+
+### Task 3: Provision Exact Cognito PKCE and Admin-Only Tenancy
+
+**Branch:** feat/prod-infra-003-cognito
+
+**Files:**
+- Modify: infra/opentofu/modules/core-cognito/**
+- Create: scripts/production/seed_cognito_demo.py
+- Create: tests/production/test_cognito_plan.py
+- Create: tests/production/test_cognito_seed.py
+
+**Interfaces:**
+- User Pool domain prefix is exactly limnopulse-portfolio-demo.
+- Public SPA client uses code flow+PKCE, no secret, exact callback/logout URLs and no SMS/social/M2M.
+- Seed uses AdminCreateUser MessageAction=SUPPRESS followed by AdminSetUserPassword Permanent=true.
+
+- [ ] **Step 1: Write exact-domain and flow tests**
+
+Reject computed suffixes, implicit domains, client secret, implicit grant, self-registration, SMS MFA and wildcard URLs.
+
+- [ ] **Step 2: Implement User Pool/domain/client**
+
+Set allow_admin_create_user_only=true. Output issuer, client ID and absolute authorization base URL as public values.
+
+- [ ] **Step 3: Write idempotent seed tests**
+
+Consume reviewed email/password through secure file descriptors; never generate/log/store password in release artifacts. Existing mismatched user fails.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_cognito_plan.py tests/production/test_cognito_seed.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/core-cognito scripts/production tests/production
+    git commit -m "feat(auth): provision exact portfolio cognito flow"
+
+### Task 4: Create the Private Static Distribution
+
+**Branch:** feat/prod-infra-004-static-web
+
+**Files:**
+- Create: infra/opentofu/modules/static-web/main.tf
+- Create: infra/opentofu/modules/static-web/variables.tf
+- Create: infra/opentofu/modules/static-web/outputs.tf
+- Create: infra/opentofu/modules/static-web/function.js
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/test_static_web_plan.py
+- Create: tests/production/test_spa_rewrite.js
+
+**Interfaces:**
+- Private us-east-2 S3 origin, OAC, CloudFront, global_edge ACM/WAF and response headers.
+- Exports distribution ID/domain, bucket name and ACM validation records only.
+- Rewrite maps extensionless app routes to /index.html and excludes assets/metadata.
+
+- [ ] **Step 1: Write resource and public-access tests**
+
+Require account/bucket block, bucket-owner-enforced, TLS policy, OAC SourceArn restriction, versioning, no website endpoint/ACL and dedicated WAF.
+
+- [ ] **Step 2: Write cache/security-header tests**
+
+Immutable release assets one year; root index bounded revalidation; CSP report-only input switch and enforcing prod acceptance; HSTS, nosniff, frame, referrer and permissions policies.
+
+- [ ] **Step 3: Implement rewrite and its table tests**
+
+Cases include /, /dashboard, /assets/app.js, /runtime-config.json, /favicon.ico and malformed URI.
+
+- [ ] **Step 4: Add lifecycle below voluntary 5 GB**
+
+Retain releases eligible for rollback; never expire the current/prior referenced unit.
+
+- [ ] **Step 5: Validate and commit**
+
+    node --test tests/production/test_spa_rewrite.js
+    uv run --locked --extra dev pytest -q tests/production/test_static_web_plan.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/static-web infra/opentofu/env/prod tests/production
+    git commit -m "feat(web-infra): add private cloudfront distribution"
+
+### Task 5: Add Runtime IAM, Alarms and Cost Policy
+
+**Branch:** feat/prod-infra-005-iam-observability
+
+**Files:**
+- Create: infra/opentofu/modules/runtime-iam/**
+- Create: infra/opentofu/modules/observability/**
+- Create: policies/limnopulse.rego
+- Create: schemas/cost-manifest.schema.json
+- Create: tests/production/test_iam_alarm_cost_plan.py
+
+**Interfaces:**
+- Distinct API, evaluator, SQS canary and backup policies; product Roles Anywhere role itself remains shared-state owned.
+- CloudWatch alarms cover DynamoDB/SQS and bounded application-facing AWS failures.
+- Cost manifest max is at most USD 3.
+
+- [ ] **Step 1: Write IAM allow/deny matrices**
+
+API reads exact table/index and Cognito identity operations needed by code; evaluator exact due-rule/event actions; canary exact queue; no wildcard table/prefix or cross-project SSM.
+
+- [ ] **Step 2: Add alarm tests**
+
+Throttles/system errors, queue age/depth/DLQ, budget/anomaly reference. No Container Insights or high-cardinality dimension.
+
+- [ ] **Step 3: Add OPA forbidden-service and tag policy**
+
+Reject NAT, ALB, database/cache/IoT/global/paid messaging. Require Project=limnopulse, Environment=prod, ManagedBy=opentofu, Owner=vinisantana where supported.
+
+- [ ] **Step 4: Validate plan fixtures and commit**
+
+    conftest test tests/fixtures/plans --policy policies
+    uv run --locked --extra dev pytest -q tests/production/test_iam_alarm_cost_plan.py
+    git add infra/opentofu/modules policies schemas tests
+    git commit -m "feat(infra): add least privilege alarms and cost policy"
+
+### Task 6: Build Credential-Free Pull-Request CI
+
+**Branch:** ci/prod-006-validation
+
+**Files:**
+- Create: .github/workflows/verify.yml
+- Modify: Makefile
+- Create: tests/production/test_ci_workflow.py
+
+**Interfaces:**
+- Jobs: python, go, frontend, compose, oci, opentofu-policy.
+- permissions at workflow root are contents:read.
+- No id-token, packages write, secrets or production environment on pull requests.
+
+- [ ] **Step 1: Write workflow contract tests**
+
+Require pinned full-SHA actions, GitHub-hosted runners, locked installs, unconditional integration teardown and uploaded SBOM/test artifacts only.
+
+- [ ] **Step 2: Add Make targets used identically locally/CI**
+
+verify-python, verify-go, verify-web, verify-compose-production, verify-oci and verify-tofu-policy.
+
+- [ ] **Step 3: Implement workflow matrix**
+
+Use cache keys bound to lockfiles; do not cache credentials. Build images but do not push on PR. Generate Syft SBOM and scan with reviewed Trivy severity policy.
+
+- [ ] **Step 4: Run workflow/static tests and local aggregate**
+
+    uv run --locked --extra dev pytest -q tests/production/test_ci_workflow.py
+    actionlint .github/workflows/verify.yml
+    make verify
+
+- [ ] **Step 5: Commit**
+
+    git add .github/workflows/verify.yml Makefile tests/production/test_ci_workflow.py
+    git commit -m "ci(prod): validate immutable portfolio artifacts"
+
+### Task 7: Define and Build the Immutable Release Manifest
+
+**Branch:** feat/prod-delivery-007-release-manifest
+
+**Files:**
+- Create: release/manifest.schema.json
+- Create: release/build_manifest.py
+- Create: release/verify_manifest.py
+- Create: tests/production/test_release_manifest.py
+- Create: .github/workflows/release.yml
+
+**Interfaces:**
+- Manifest binds source SHA, CI run IDs, API/evaluator/publisher digests, frontend checksum, Compose checksum, SBOM checksums and OpenTofu/provider-lock digest.
+- Manifest expires and is canonical JSON; no mutable tag is authoritative.
+
+- [ ] **Step 1: Write canonical schema and mixing tests**
+
+Reject image tag without digest, mismatched source/run, missing SBOM, altered Compose/web checksum, future schema, expired manifest and secret-like field.
+
+- [ ] **Step 2: Implement deterministic canonical JSON builder**
+
+Sort keys, UTF-8, no whitespace, SHA-256 sidecar. Validate every path/digest against files produced by the same run.
+
+- [ ] **Step 3: Implement main-only release workflow**
+
+It requires verify workflow success for the exact main SHA, builds once, pushes GHCR by digest, creates web archive and uploads one bounded release artifact. permissions are contents:read, packages:write only for this job.
+
+- [ ] **Step 4: Verify and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_release_manifest.py
+    actionlint .github/workflows/release.yml
+    git add release tests/production/test_release_manifest.py .github/workflows/release.yml
+    git commit -m "feat(release): bind portfolio artifacts to one sha"
+
+### Task 8: Add Manual Product Plan and Apply Callers
+
+**Branch:** ci/prod-008-plan-apply
+
+**Files:**
+- Create: .github/workflows/infra-plan.yml
+- Create: .github/workflows/infra-apply.yml
+- Create: release/infra-plan.schema.json
+- Create: tests/production/test_infra_workflows.py
+
+**Interfaces:**
+- Plan calls the exact immutable LimnoPulse plan gate in personal-infra-live.
+- Apply inputs are plan_run_id, artifact_id and artifact_digest; it calls the exact deploy gate.
+- Apply never replans or runs on merge.
+
+- [ ] **Step 1: Write trust/gate ordering tests**
+
+Artifact verification is before reusable call/OIDC. Caller permissions are contents:read, actions:read, id-token:write only where reusable gate needs it.
+
+- [ ] **Step 2: Implement plan artifact composition**
+
+Include binary/redacted plan, SHA, backend key, lock digest, policy, cost<=3, aggregate<=15 evidence, expiry and manifest digest.
+
+- [ ] **Step 3: Implement apply caller**
+
+Require main SHA/ref and exact plan identity. No destroy input and no auto-approve except exact reviewed binary plan inside reusable gate.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_infra_workflows.py
+    actionlint .github/workflows/infra-*.yml
+    git add .github/workflows release tests/production/test_infra_workflows.py
+    git commit -m "ci(infra): add manual limnopulse plan and apply"
+
+### Task 9: Implement CloudFront Free Subscription Reconciliation
+
+**Branch:** feat/prod-delivery-009-free-plan
+
+**Files:**
+- Create: scripts/deploy/reconcile_cloudfront_free.py
+- Create: tests/production/test_cloudfront_free.py
+- Create: docs/runbooks/cloudfront-free.md
+
+**Interfaces:**
+- Inputs are exact distribution ID/ARN and dedicated WAF ARN plus expected FREE tier.
+- Endpoint region is us-east-1.
+- Output evidence is subscription ARN, ETag, association hashes and ACTIVE state without account identifiers.
+
+- [ ] **Step 1: Write eligibility/quota/refusal tests**
+
+Reject ineligible account, fewer than two phase-one slots before first cutover, conflicting subscription, paid tier, ambiguous association, replacement/cancel request and non-ACTIVE result.
+
+- [ ] **Step 2: Implement list/read/create-if-absent/re-read**
+
+Use a typed API adapter for fixture tests. Operation is idempotent only for the exact distribution/WAF/FREE tuple.
+
+- [ ] **Step 3: Add drift-only mode**
+
+Every later plan invokes check mode; it never mutates. The deployment mode is explicit and manual, outside OpenTofu/local-exec.
+
+- [ ] **Step 4: Run and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_cloudfront_free.py
+    git add scripts/deploy tests/production/test_cloudfront_free.py docs/runbooks/cloudfront-free.md
+    git commit -m "feat(edge): reconcile exact cloudfront free subscription"
+
+### Task 10: Implement Atomic Static Release and Rollback
+
+**Branch:** feat/prod-delivery-010-static-release
+
+**Files:**
+- Create: scripts/deploy/publish_static.py
+- Create: scripts/deploy/rollback_static.py
+- Create: tests/production/test_static_release.py
+- Create: docs/runbooks/static-release.md
+
+**Interfaces:**
+- Uploads releases/<release_id>/ immutable unit completely, verifies checksum/content type/cache, then writes root index.html last.
+- Rollback copies/restores the prior versioned root index and invalidates only entrypoints.
+
+- [ ] **Step 1: Write failure-injection tests**
+
+Network/error at each object leaves root index unchanged. Index referencing mixed release IDs is rejected. Existing release object with different checksum is immutable conflict.
+
+- [ ] **Step 2: Implement runtime-config generation**
+
+Generate public config from exact OpenTofu outputs and manifest; reject unknown/secret fields. All asset references must begin with one release prefix.
+
+- [ ] **Step 3: Implement last-write and version evidence**
+
+Use conditional write against prior ETag/version where supported; record new/prior version IDs. Invalidate /index.html only.
+
+- [ ] **Step 4: Run emulator/fake tests and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_static_release.py
+    git add scripts/deploy tests/production/test_static_release.py docs/runbooks/static-release.md
+    git commit -m "feat(delivery): publish atomic static release units"
+
+### Task 11: Implement Manual Host Promotion and Timers
+
+**Branch:** feat/prod-delivery-011-host-promotion
+
+**Files:**
+- Create: .github/workflows/promote-production.yml
+- Create: release/host-envelope.schema.json
+- Create: scripts/deploy/build_host_archive.py
+- Create: scripts/deploy/verify_promotion.py
+- Create: config/systemd/limnopulse-evaluator.service
+- Create: config/systemd/limnopulse-evaluator.timer
+- Create: config/systemd/limnopulse-synthetic.service
+- Create: config/systemd/limnopulse-synthetic.timer
+- Create: tests/production/test_promotion.py
+- Create: tests/production/test_systemd_units.py
+
+**Interfaces:**
+- Workflow verifies a green main release artifact with its repository GITHUB_TOKEN, then calls immutable personal-infra-live LimnoPulse host gate.
+- Host archive contains manifest, production Compose and non-secret config only.
+- Timers invoke fixed digest-bound one-shot services and share the platform lease.
+
+- [ ] **Step 1: Write workflow evidence tests**
+
+Require actions:read, contents:read and packages:read only; exact run/artifact/SHA/digest/expiry verification before reusable gate. No PAT or SSH secret.
+
+- [ ] **Step 2: Write timer overlap/credential tests**
+
+Evaluator and publisher use flock/host dispatcher, no permanent loop, conservative cadence, bounded timeout and only run after renewed credential evidence where AWS is needed.
+
+- [ ] **Step 3: Implement promotion sequence**
+
+Candidate alternate loopback -> Cognito/membership/Dynamo/Influx read smoke -> Nginx switch -> timer digest update -> static immutable upload/root switch -> synthetic publish -> wait window -> evaluator -> incident/read verification -> redacted evidence.
+
+- [ ] **Step 4: Implement rollback evidence**
+
+Restore prior API upstream/digest, timer digests and root index. Never remove Influx volume or roll DynamoDB backward.
+
+- [ ] **Step 5: Validate and commit**
+
+    uv run --locked --extra dev pytest -q tests/production/test_promotion.py tests/production/test_systemd_units.py
+    actionlint .github/workflows/promote-production.yml
+    git add .github/workflows release scripts/deploy config/systemd tests/production
+    git commit -m "feat(delivery): promote portfolio through shared host gate"
+
+### Task 12: Add Production Acceptance, Backup and Cost-Freeze Drills
+
+**Branch:** test/prod-delivery-012-acceptance
+
+**Files:**
+- Create: tests/production/test_delivery_acceptance.py
+- Create: docs/runbooks/production-acceptance.md
+- Create: docs/runbooks/influx-backup-restore.md
+- Create: docs/runbooks/rollback.md
+- Create: docs/runbooks/cost-freeze.md
+
+**Interfaces:**
+- Produces the final release checklist, not an automatic deployment.
+- Requires separate operator evidence for real AWS/Cloudflare/VPS steps.
+
+- [ ] **Step 1: Add the pre-production matrix**
+
+Cover exact CORS, portfolio startup absence, renewal, Compose isolation, MQTT matrix, cross-tenant denial, Dynamo semantics, SQS canary, Influx backup/restore, unknown-device drop, evaluator fencing, deterministic first incident, CDN private origin/release rollback/CSP/no SW, exact Cognito, disabled resource/secret absence, visitor-IP rate limit and aggregate cost.
+
+- [ ] **Step 2: Add production smoke commands**
+
+Verify limnopulse.com release/TLS/private origin, API only through Tunnel, PKCE membership, synthetic MQTT->Influx->API, evaluator incident, zero provider calls, backup checksum and API/static rollback.
+
+- [ ] **Step 3: Add quarterly isolated Influx restore**
+
+Restore into a new volume/container and query one synthetic bounded time range; never replace production volume.
+
+- [ ] **Step 4: Add cost-freeze rehearsal**
+
+Prove promotion/new costly automation denied at USD 15 while API reads, audit/backup and MFA break-glass remain available.
+
+- [ ] **Step 5: Run the complete non-mutating gate**
+
+    make verify
+    make verify-production-application
+    tofu -chdir=infra/opentofu fmt -check -recursive
+    tofu -chdir=infra/opentofu init -backend=false -input=false
+    tofu -chdir=infra/opentofu validate -no-color
+    conftest test tests/fixtures/plans --policy policies
+    uv run --locked --extra dev pytest -q tests/production
+    git diff --check
+
+- [ ] **Step 6: Commit**
+
+    git add tests/production/test_delivery_acceptance.py docs/runbooks
+    git commit -m "test(prod): define infrastructure and delivery acceptance"
+
+## Execution Order
+
+Tasks 1-3 are serial around existing state addresses. Tasks 4 and 5 may proceed after Task 1. Task 6 waits for the application plan. Task 7 waits for Task 6. Task 8 waits for Tasks 1-7 and the personal-infra-live gate. Task 9 waits for Task 4. Task 10 waits for Tasks 4 and 7. Task 11 waits for Tasks 7-10 and the infra-ansible dispatcher. Task 12 is final. Real deployment remains separate and manual.
+
+## Plan Self-Review Record
+
+- Resource ownership: no shared KMS, SSM values, Budget, OIDC, Roles Anywhere, tunnel, DNS or host resource is recreated.
+- Feature absence: unconditional SES/Telegram resources are eliminated; disabled plans contain zero related address/secret/IAM output.
+- Region consistency: us-east-2 default; only ACM/WAF/Pricing Plan Manager uses us-east-1.
+- Cost consistency: product max USD 3, two-slot Free-plan gate and aggregate USD 15 evidence.
+- Delivery consistency: one manifest binds all artifacts; plan/apply/promotion are manual and immutable.
+- Rollback consistency: API, timers and root index restore independently without deleting Influx/Dynamo data.
+- Completeness scan: no unresolved marker, paid fallback or implicit provider selection.
+
+## Execution Handoff
+
+Use isolated worktrees and reviewed PRs. Merge Tasks 1-12 before requesting the first real OpenTofu plan. The first production rollout must follow LimnoPulse acceptance and rollback drills before any CnesData production work begins.


### PR DESCRIPTION
## Summary

- adds the portfolio-demo application implementation plan
- adds the product AWS infrastructure and manual delivery plan
- depends on the existing V4 P0/M1 plan instead of duplicating it
- structurally omits Redis, Telegram, SES, Push, SMS, Stripe, AWS IoT and commands

## Safety and cost

- documentation only; no deploy or infrastructure apply
- AWS default `us-east-2`; ACM/WAF/Pricing Plan Manager only in `us-east-1`
- LimnoPulse envelope USD 3; exact CloudFront FREE gate with no paid fallback
- GitHub-hosted runners and GitHub Free assumptions only

## Review focus

Please validate the V4 dependency gate, portfolio startup absence tests, deterministic frontend, MQTT principal separation, independent production Compose and immutable promotion/rollback sequence.