### PR TITLE
ci: add reproducible verification gates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,49 @@
+name: verify
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_EC2_METADATA_DISABLED: "true"
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - run: make verify-python
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+      - run: make verify-go
+  opentofu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        with:
+          tofu_version: 1.8.0
+          tofu_wrapper: false
+      - run: make verify-tofu
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - run: make verify-compose

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+UV ?= uv
+TOFU ?= tofu
+
+.PHONY: verify verify-python verify-go verify-tofu verify-compose
+
+verify: verify-python verify-go verify-tofu verify-compose
+
+verify-python:
+	$(UV) lock --check
+	$(UV) sync --locked --extra dev
+	$(UV) run --locked --no-sync python -m pytest -q
+
+verify-go:
+	go test -race ./...
+
+verify-tofu:
+	$(TOFU) -chdir=infra/opentofu init -backend=false -input=false
+	$(TOFU) -chdir=infra/opentofu fmt -check -recursive
+	$(TOFU) -chdir=infra/opentofu validate -no-color
+
+verify-compose:
+	docker compose config --quiet

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,41 @@
+# Verification
+
+LimnoPulse exposes the same credential-free verification boundaries to local
+contributors and GitHub Actions. The gates reproduce repository dependency and
+configuration inputs; they do not promise byte-identical local toolchains.
+
+## Prerequisites
+
+Install GNU Make, Python 3.12 or newer, uv, the Go version declared by
+`go.mod`, OpenTofu 1.8.0 or newer, and Docker with the Compose plugin. The uv
+and OpenTofu binaries can be overridden with the `UV` and `TOFU` Make
+variables when a controlled local binary is required.
+
+## Local gates
+
+- `make verify-python` checks that `uv.lock` matches `pyproject.toml`, syncs
+  the `dev` extra from the lock, and runs the normal repository pytest suite.
+- `make verify-go` runs all repository Go tests with the race detector using
+  `go.mod` and `go.sum`.
+- `make verify-tofu` initializes `infra/opentofu` with the configured backend
+  disabled, checks recursive formatting, and validates the configuration.
+- `make verify-compose` parses and validates `compose.yaml` quietly. It does
+  not start, build, pull, or create services.
+- `make verify` runs all four boundaries.
+
+The Python suite includes `tests/integration/test_notifications_local.py`, but
+that multiprocess integration remains opt-in. It is skipped unless
+`RUN_NOTIFICATION_INTEGRATION=1` is set after its required local services have
+been started explicitly.
+
+## Safety and readiness boundary
+
+These gates use no AWS credentials. OpenTofu initialization has its backend
+disabled, and verification never runs `tofu plan` or `tofu apply`. Compose is
+parsed only and does not start services. Public package and provider registries
+may still be contacted to install locked dependencies or provider plugins, so
+credential-free does not mean offline.
+
+Passing these checks does not establish AWS sandbox or production readiness.
+Cloud deployment, remote-state configuration, environment smoke tests, and
+operational readiness remain a later gate.

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_verify_workflow_is_read_only_and_credential_free() -> None:
+    text = (ROOT / ".github/workflows/verify.yml").read_text(encoding="utf-8")
+
+    assert "pull_request:" in text
+    assert "branches: [main]" in text
+    assert "contents: read" in text
+    assert 'AWS_EC2_METADATA_DISABLED: "true"' in text
+
+    lowered = text.lower()
+    for forbidden in (
+        "secrets.",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "tofu plan",
+        "tofu apply",
+        "docker compose up",
+    ):
+        assert forbidden not in lowered
+
+    action_refs = re.findall(r"^\s*-\s+uses:\s+(\S+)", text, flags=re.MULTILINE)
+    assert action_refs
+    assert all(re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", ref) for ref in action_refs)
+    assert {ref.partition("@")[0] for ref in action_refs} == {
+        "actions/checkout",
+        "actions/setup-go",
+        "actions/setup-python",
+        "astral-sh/setup-uv",
+        "opentofu/setup-opentofu",
+    }
+
+    workflow = yaml.load(text, Loader=yaml.BaseLoader)
+    assert set(workflow["jobs"]) == {
+        "python",
+        "go",
+        "opentofu",
+        "compose",
+    }
+    expected_jobs = {
+        "python": (
+            ["actions/checkout", "actions/setup-python", "astral-sh/setup-uv"],
+            "verify-python",
+        ),
+        "go": (["actions/checkout", "actions/setup-go"], "verify-go"),
+        "opentofu": (["actions/checkout", "opentofu/setup-opentofu"], "verify-tofu"),
+        "compose": (["actions/checkout"], "verify-compose"),
+    }
+    for job_name, (expected_actions, target) in expected_jobs.items():
+        steps = workflow["jobs"][job_name]["steps"]
+        actions = [step["uses"].partition("@")[0] for step in steps if "uses" in step]
+        runs = [step["run"] for step in steps if "run" in step]
+        assert actions == expected_actions
+        assert runs == [f"make {target}"]
+
+
+def test_makefile_exposes_safe_reproducible_targets() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    expected = {
+        "verify-python": [
+            "uv lock --check",
+            "uv sync --locked --extra dev",
+            "uv run --locked --no-sync python -m pytest -q",
+        ],
+        "verify-go": ["go test -race ./..."],
+        "verify-tofu": [
+            "tofu -chdir=infra/opentofu init -backend=false -input=false",
+            "tofu -chdir=infra/opentofu fmt -check -recursive",
+            "tofu -chdir=infra/opentofu validate -no-color",
+        ],
+        "verify-compose": ["docker compose config --quiet"],
+    }
+
+    phony_match = re.search(r"^\.PHONY:\s+(.+)$", makefile, flags=re.MULTILINE)
+    assert phony_match is not None
+    assert set(phony_match.group(1).split()) == {"verify", *expected}
+
+    for target, commands in expected.items():
+        result = subprocess.run(
+            ["make", "--no-print-directory", "-n", "UV=uv", "TOFU=tofu", target],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.splitlines() == commands
+
+    aggregate = subprocess.run(
+        ["make", "--no-print-directory", "-n", "UV=uv", "TOFU=tofu", "verify"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert aggregate.returncode == 0, aggregate.stderr
+    assert aggregate.stdout.splitlines() == [
+        command for commands in expected.values() for command in commands
+    ]
+
+    lowered = makefile.lower()
+    for forbidden in ("tofu plan", "tofu apply", "docker compose up"):
+        assert forbidden not in lowered
+
+
+def test_verification_docs_define_the_non_production_boundary() -> None:
+    text = (ROOT / "docs/verification.md").read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    for target in (
+        "make verify-python",
+        "make verify-go",
+        "make verify-tofu",
+        "make verify-compose",
+        "make verify",
+    ):
+        assert f"`{target}`" in text
+
+    assert "tests/integration/test_notifications_local.py" in text
+    assert "RUN_NOTIFICATION_INTEGRATION=1" in text
+    assert "backend" in lowered and "disabled" in lowered
+    assert "compose" in lowered and "parse" in lowered
+    assert "does not start" in lowered
+    assert "aws credentials" in lowered
+    assert "sandbox" in lowered
+    assert "production readiness" in lowered
+    assert "later gate" in lowered


### PR DESCRIPTION
## Scope

- add `make verify-python`, `make verify-go`, `make verify-tofu`, `make verify-compose`, and aggregate `make verify`
- add independent `python`, `go`, `opentofu`, and `compose` GitHub Actions jobs for pull requests and pushes to `main`
- pin every action reference to a full lowercase 40-hex commit SHA and grant only `contents: read`
- document the credential-free, non-production verification boundary
- add focused workflow, Make dry-run, and documentation contract tests

## Explicit exclusions

- no dependency or lockfile changes
- no runtime, Compose source, or OpenTofu source changes
- no secrets or AWS access keys
- no remote backend access, `tofu plan`, or `tofu apply`
- no Compose service startup
- no AWS sandbox or production-readiness claim
- no uv CLI version input; the accepted contract reproduces dependency/configuration inputs through `uv.lock`

## RED -> GREEN evidence

Each contract was written before its production artifact.

- workflow RED: `uv run --locked --extra dev pytest -q tests/unit/test_ci_contract.py::test_verify_workflow_is_read_only_and_credential_free` -> exit 1, expected `FileNotFoundError` for `.github/workflows/verify.yml`; GREEN -> exit 0, 1 passed
- Make RED: `uv run --locked --extra dev pytest -q tests/unit/test_ci_contract.py::test_makefile_exposes_safe_reproducible_targets` -> exit 1, expected `FileNotFoundError` for `Makefile`; GREEN -> exit 0, 1 passed
- docs RED: `uv run --locked --extra dev pytest -q tests/unit/test_ci_contract.py::test_verification_docs_define_the_non_production_boundary` -> exit 1, expected `FileNotFoundError` for `docs/verification.md`; GREEN -> exit 0, 1 passed
- final owned contract: `uv run --locked --extra dev pytest -q tests/unit/test_ci_contract.py` -> exit 0, 3 passed

Mutation checks proved the tests reject an `@main` action ref, a `docker compose up -d` recipe, removal of `RUN_NOTIFICATION_INTEGRATION=1`, and removal of the exact aggregate `make verify` documentation entry. All mutations were restored before final verification.

## Verification

Exact local commands and observed results:

- `uv run --locked --extra dev pytest -q tests/unit/test_ci_contract.py` -> exit 0; 3 passed
- `make verify-python` -> exit 0; lock check/sync succeeded; 339 passed, 5 skipped, 1 warning
- `make verify-go` -> exit 0; `go test -race ./...` passed across all listed packages
- `make verify-tofu` -> exit 0; backend-disabled init and format check passed; configuration valid
- `make verify-compose` -> exit 0; configuration parsed quietly and no service started
- `make verify` -> exit 0; all four boundaries passed together
- `git diff --check` -> exit 0
- `git diff --exit-code origin/main -- pyproject.toml uv.lock go.mod go.sum infra/opentofu/.terraform.lock.hcl compose.yaml` -> exit 0

The complete aggregate gate was rerun immediately before push and exited 0.

## Pre-existing warnings

- Python reports one existing Starlette/httpx deprecation warning.
- OpenTofu reports six existing DynamoDB argument-deprecation warnings.

Neither warning was introduced or changed by this PR.

## Risks and remote checks

- the setup-uv action is immutable, but the uv CLI remains intentionally unpinned per the accepted ruling
- local verification used Python 3.14.6 while CI selects Python 3.12; the project supports Python 3.12+
- GitHub-hosted runner images and public package/provider availability remain external inputs
- remote verification at head `ce15cc04cb11137379815692bc9e8066104265be`: `python` COMPLETED/SUCCESS, `go` COMPLETED/SUCCESS, `opentofu` COMPLETED/SUCCESS, and `compose` COMPLETED/SUCCESS

## Ownership confirmation

Exactly these owned files changed:

- `.github/workflows/verify.yml`
- `Makefile`
- `docs/verification.md`
- `tests/unit/test_ci_contract.py`

## Rollback

Revert commit `ce15cc04cb11137379815692bc9e8066104265be`. No cloud resource or service was created.

Closes #27