### PR TITLE
test: freeze v1 contract and architecture conformance

### DIFF
--- a/scripts/dev/export_v1_openapi.py
+++ b/scripts/dev/export_v1_openapi.py
@@ -1,0 +1,30 @@
+import argparse
+from pathlib import Path
+
+from limnopulse_api.api.openapi_contract import render_v1_openapi_contract
+from limnopulse_api.core.config import Settings
+from limnopulse_api.main import create_app
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output", type=Path, default=Path("tests/contracts/openapi/v1.json")
+    )
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    rendered = render_v1_openapi_contract(
+        create_app(Settings(app_env="test", auth_mode="dev"))
+    )
+    if args.check:
+        return int(
+            not args.output.exists()
+            or args.output.read_text(encoding="utf-8") != rendered
+        )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/limnopulse_api/api/openapi_contract.py
+++ b/src/limnopulse_api/api/openapi_contract.py
@@ -5,14 +5,29 @@ from collections.abc import Iterable
 from copy import deepcopy
 from typing import Any
 
+import fastapi.routing as fastapi_routing
 from fastapi import FastAPI
-from fastapi.routing import APIRoute, iter_route_contexts
+from fastapi.routing import APIRoute
 
 _CANONICAL_422_DESCRIPTION = "Unprocessable Entity"
 _PYTHON_422_DESCRIPTIONS = frozenset(
     {_CANONICAL_422_DESCRIPTION, "Unprocessable Content"}
 )
 _ERROR_RESPONSE_SCHEMA = {"$ref": "#/components/schemas/ErrorResponse"}
+_OPENAPI_METHODS = frozenset(
+    {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
+)
+
+
+def iter_effective_api_routes(app: FastAPI) -> Iterable[Any]:
+    iter_route_contexts = getattr(fastapi_routing, "iter_route_contexts", None)
+    if iter_route_contexts is None:
+        yield from (route for route in app.routes if isinstance(route, APIRoute))
+        return
+
+    for context in iter_route_contexts(app.routes):
+        if isinstance(context.original_route, APIRoute) and context.path_format is not None:
+            yield context
 
 
 def _component_refs(value: Any) -> set[tuple[str, str]]:
@@ -34,8 +49,32 @@ def _component_refs(value: Any) -> set[tuple[str, str]]:
     return refs
 
 
+def _operation_security_refs(paths: Iterable[Any]) -> set[tuple[str, str]]:
+    refs: set[tuple[str, str]] = set()
+    for path_item in paths:
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method not in _OPENAPI_METHODS or not isinstance(operation, dict):
+                continue
+            security = operation.get("security")
+            if not isinstance(security, list):
+                continue
+            for requirement in security:
+                if isinstance(requirement, dict):
+                    refs.update(
+                        ("securitySchemes", name)
+                        for name in requirement
+                        if isinstance(name, str)
+                    )
+    return refs
+
+
 def _reachable_components(components: dict[str, Any], roots: Iterable[Any]) -> dict[str, Any]:
-    pending = list(_component_refs(list(roots)))
+    root_values = list(roots)
+    pending = list(
+        _component_refs(root_values) | _operation_security_refs(root_values)
+    )
     selected: dict[str, dict[str, Any]] = {}
     while pending:
         section, name = pending.pop()
@@ -52,14 +91,12 @@ def _reachable_components(components: dict[str, Any], roots: Iterable[Any]) -> d
 
 def _implicit_422_operations(app: FastAPI) -> set[tuple[str, str]]:
     operations: set[tuple[str, str]] = set()
-    for context in iter_route_contexts(app.routes):
-        if not isinstance(context.original_route, APIRoute) or context.path_format is None:
-            continue
-        declared_response = context.responses.get(422, context.responses.get("422"))
+    for route in iter_effective_api_routes(app):
+        declared_response = route.responses.get(422, route.responses.get("422"))
         if not isinstance(declared_response, dict) or "description" in declared_response:
             continue
         operations.update(
-            (context.path_format, method.lower()) for method in context.methods or ()
+            (route.path_format, method.lower()) for method in route.methods or ()
         )
     return operations
 

--- a/src/limnopulse_api/api/openapi_contract.py
+++ b/src/limnopulse_api/api/openapi_contract.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import Any
 
 from fastapi import FastAPI
+from fastapi.routing import APIRoute, iter_route_contexts
 
 _CANONICAL_422_DESCRIPTION = "Unprocessable Entity"
 _PYTHON_422_DESCRIPTIONS = frozenset(
@@ -49,10 +50,26 @@ def _reachable_components(components: dict[str, Any], roots: Iterable[Any]) -> d
     }
 
 
-def _normalize_422_descriptions(paths: dict[str, Any]) -> None:
-    for path_item in paths.values():
-        for operation in path_item.values():
-            if not isinstance(operation, dict):
+def _implicit_422_operations(app: FastAPI) -> set[tuple[str, str]]:
+    operations: set[tuple[str, str]] = set()
+    for context in iter_route_contexts(app.routes):
+        if not isinstance(context.original_route, APIRoute) or context.path_format is None:
+            continue
+        declared_response = context.responses.get(422, context.responses.get("422"))
+        if not isinstance(declared_response, dict) or "description" in declared_response:
+            continue
+        operations.update(
+            (context.path_format, method.lower()) for method in context.methods or ()
+        )
+    return operations
+
+
+def _normalize_422_descriptions(
+    paths: dict[str, Any], implicit_operations: set[tuple[str, str]]
+) -> None:
+    for path, path_item in paths.items():
+        for method, operation in path_item.items():
+            if (path, method) not in implicit_operations or not isinstance(operation, dict):
                 continue
             responses = operation.get("responses")
             if not isinstance(responses, dict):
@@ -79,7 +96,7 @@ def build_v1_openapi_contract(app: FastAPI) -> dict[str, Any]:
         for path in sorted(schema["paths"])
         if path.startswith("/v1/")
     }
-    _normalize_422_descriptions(paths)
+    _normalize_422_descriptions(paths, _implicit_422_operations(app))
     return {
         "openapi": schema["openapi"],
         "info": schema["info"],

--- a/src/limnopulse_api/api/openapi_contract.py
+++ b/src/limnopulse_api/api/openapi_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any
+
+from fastapi import FastAPI
+
+_CANONICAL_422_DESCRIPTION = "Unprocessable Entity"
+_PYTHON_422_DESCRIPTIONS = frozenset(
+    {_CANONICAL_422_DESCRIPTION, "Unprocessable Content"}
+)
+_ERROR_RESPONSE_SCHEMA = {"$ref": "#/components/schemas/ErrorResponse"}
+
+
+def _component_refs(value: Any) -> set[tuple[str, str]]:
+    refs: set[tuple[str, str]] = set()
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/components/"):
+                _, _, section, name = ref.split("/", 3)
+                refs.add((section, name))
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    return refs
+
+
+def _reachable_components(components: dict[str, Any], roots: Iterable[Any]) -> dict[str, Any]:
+    pending = list(_component_refs(list(roots)))
+    selected: dict[str, dict[str, Any]] = {}
+    while pending:
+        section, name = pending.pop()
+        values = components.get(section, {})
+        if name not in values or name in selected.get(section, {}):
+            continue
+        selected.setdefault(section, {})[name] = values[name]
+        pending.extend(_component_refs(values[name]))
+    return {
+        section: {name: selected[section][name] for name in sorted(selected[section])}
+        for section in sorted(selected)
+    }
+
+
+def _normalize_422_descriptions(paths: dict[str, Any]) -> None:
+    for path_item in paths.values():
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+            responses = operation.get("responses")
+            if not isinstance(responses, dict):
+                continue
+            response = responses.get("422")
+            if not isinstance(response, dict):
+                continue
+            schema = (
+                response.get("content", {})
+                .get("application/json", {})
+                .get("schema")
+            )
+            if (
+                response.get("description") in _PYTHON_422_DESCRIPTIONS
+                and schema == _ERROR_RESPONSE_SCHEMA
+            ):
+                response["description"] = _CANONICAL_422_DESCRIPTION
+
+
+def build_v1_openapi_contract(app: FastAPI) -> dict[str, Any]:
+    schema = app.openapi()
+    paths = {
+        path: deepcopy(schema["paths"][path])
+        for path in sorted(schema["paths"])
+        if path.startswith("/v1/")
+    }
+    _normalize_422_descriptions(paths)
+    return {
+        "openapi": schema["openapi"],
+        "info": schema["info"],
+        "paths": paths,
+        "components": _reachable_components(schema.get("components", {}), paths.values()),
+    }
+
+
+def render_v1_openapi_contract(app: FastAPI) -> str:
+    return json.dumps(build_v1_openapi_contract(app), indent=2, sort_keys=True) + "\n"

--- a/tests/contracts/openapi/v1.json
+++ b/tests/contracts/openapi/v1.json
@@ -1,0 +1,3841 @@
+{
+  "components": {
+    "schemas": {
+      "AlertAggregation": {
+        "enum": [
+          "min",
+          "max",
+          "mean",
+          "last"
+        ],
+        "title": "AlertAggregation",
+        "type": "string"
+      },
+      "AlertChannel": {
+        "enum": [
+          "email",
+          "telegram"
+        ],
+        "title": "AlertChannel",
+        "type": "string"
+      },
+      "AlertEventListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AlertEventResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "AlertEventListResponse",
+        "type": "object"
+      },
+      "AlertEventResponse": {
+        "properties": {
+          "acknowledged_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acknowledged At"
+          },
+          "acknowledged_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acknowledged By"
+          },
+          "aggregation": {
+            "$ref": "#/components/schemas/AlertAggregation"
+          },
+          "confirmed_open_window_end": {
+            "format": "date-time",
+            "title": "Confirmed Open Window End",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "evaluation_revision": {
+            "minimum": 1.0,
+            "title": "Evaluation Revision",
+            "type": "integer"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "last_evaluated_at": {
+            "format": "date-time",
+            "title": "Last Evaluated At",
+            "type": "string"
+          },
+          "last_evaluation_quality": {
+            "title": "Last Evaluation Quality",
+            "type": "string"
+          },
+          "last_evaluation_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Evaluation Value"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/AlertMetric"
+          },
+          "opened_at": {
+            "format": "date-time",
+            "title": "Opened At",
+            "type": "string"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/AlertOperator"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          },
+          "resolved_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved By"
+          },
+          "rule_id": {
+            "title": "Rule Id",
+            "type": "string"
+          },
+          "rule_name": {
+            "title": "Rule Name",
+            "type": "string"
+          },
+          "rule_version": {
+            "minimum": 1.0,
+            "title": "Rule Version",
+            "type": "integer"
+          },
+          "schema_version": {
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AlertEventStatus"
+          },
+          "suppression_source_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suppression Source Event Id"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "number"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "window_end": {
+            "format": "date-time",
+            "title": "Window End",
+            "type": "string"
+          },
+          "window_start": {
+            "format": "date-time",
+            "title": "Window Start",
+            "type": "string"
+          }
+        },
+        "required": [
+          "created_at",
+          "updated_at",
+          "version",
+          "status",
+          "tenant_id",
+          "event_id",
+          "rule_id",
+          "rule_version",
+          "evaluation_revision",
+          "rule_name",
+          "pond_id",
+          "metric",
+          "operator",
+          "threshold",
+          "aggregation",
+          "severity",
+          "opened_at",
+          "confirmed_open_window_end",
+          "window_start",
+          "window_end",
+          "last_evaluated_at",
+          "last_evaluation_quality"
+        ],
+        "title": "AlertEventResponse",
+        "type": "object"
+      },
+      "AlertEventStatus": {
+        "enum": [
+          "open",
+          "acknowledged",
+          "suppressed",
+          "resolved"
+        ],
+        "title": "AlertEventStatus",
+        "type": "string"
+      },
+      "AlertEventTransitionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "expected_version": {
+            "minimum": 1.0,
+            "title": "Expected Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "expected_version"
+        ],
+        "title": "AlertEventTransitionRequest",
+        "type": "object"
+      },
+      "AlertMetric": {
+        "enum": [
+          "temp_c",
+          "ph",
+          "do_mg_l",
+          "turbidity_ntu",
+          "salinity_ppt",
+          "battery_v",
+          "rssi"
+        ],
+        "title": "AlertMetric",
+        "type": "string"
+      },
+      "AlertOperator": {
+        "enum": [
+          "<",
+          "<=",
+          ">",
+          ">="
+        ],
+        "title": "AlertOperator",
+        "type": "string"
+      },
+      "AlertRuleCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "$ref": "#/components/schemas/AlertAggregation"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/AlertChannel"
+            },
+            "minItems": 1,
+            "title": "Channels",
+            "type": "array"
+          },
+          "cooldown_seconds": {
+            "maximum": 86400.0,
+            "minimum": 60.0,
+            "title": "Cooldown Seconds",
+            "type": "integer"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "duration": {
+            "title": "Duration",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/AlertMetric"
+          },
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/AlertOperator"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "number"
+          },
+          "window": {
+            "title": "Window",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pond_id",
+          "metric",
+          "name",
+          "operator",
+          "threshold",
+          "aggregation",
+          "window",
+          "duration",
+          "severity",
+          "channels",
+          "cooldown_seconds",
+          "enabled"
+        ],
+        "title": "AlertRuleCreate",
+        "type": "object"
+      },
+      "AlertRuleListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AlertRuleResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "AlertRuleListResponse",
+        "type": "object"
+      },
+      "AlertRuleReplace": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "$ref": "#/components/schemas/AlertAggregation"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/AlertChannel"
+            },
+            "minItems": 1,
+            "title": "Channels",
+            "type": "array"
+          },
+          "cooldown_seconds": {
+            "maximum": 86400.0,
+            "minimum": 60.0,
+            "title": "Cooldown Seconds",
+            "type": "integer"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "duration": {
+            "title": "Duration",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "expected_version": {
+            "minimum": 1.0,
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/AlertMetric"
+          },
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/AlertOperator"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "number"
+          },
+          "window": {
+            "title": "Window",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pond_id",
+          "metric",
+          "name",
+          "operator",
+          "threshold",
+          "aggregation",
+          "window",
+          "duration",
+          "severity",
+          "channels",
+          "cooldown_seconds",
+          "enabled",
+          "expected_version"
+        ],
+        "title": "AlertRuleReplace",
+        "type": "object"
+      },
+      "AlertRuleReplacementResponse": {
+        "properties": {
+          "replaced": {
+            "$ref": "#/components/schemas/AlertRuleResponse"
+          },
+          "replacement": {
+            "$ref": "#/components/schemas/AlertRuleResponse"
+          }
+        },
+        "required": [
+          "replaced",
+          "replacement"
+        ],
+        "title": "AlertRuleReplacementResponse",
+        "type": "object"
+      },
+      "AlertRuleResponse": {
+        "properties": {
+          "aggregation": {
+            "$ref": "#/components/schemas/AlertAggregation"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/AlertChannel"
+            },
+            "title": "Channels",
+            "type": "array"
+          },
+          "cooldown_seconds": {
+            "title": "Cooldown Seconds",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "duration": {
+            "title": "Duration",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/AlertMetric"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/AlertOperator"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "replaced_by_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replaced By Rule Id"
+          },
+          "replaces_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replaces Rule Id"
+          },
+          "rule_id": {
+            "title": "Rule Id",
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "number"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "window": {
+            "title": "Window",
+            "type": "string"
+          }
+        },
+        "required": [
+          "created_at",
+          "updated_at",
+          "version",
+          "status",
+          "tenant_id",
+          "rule_id",
+          "pond_id",
+          "metric",
+          "name",
+          "operator",
+          "threshold",
+          "aggregation",
+          "window",
+          "duration",
+          "severity",
+          "channels",
+          "cooldown_seconds",
+          "enabled"
+        ],
+        "title": "AlertRuleResponse",
+        "type": "object"
+      },
+      "AlertRuleUpdate": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AlertAggregation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "channels": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AlertChannel"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channels"
+          },
+          "cooldown_seconds": {
+            "anyOf": [
+              {
+                "maximum": 86400.0,
+                "minimum": 60.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cooldown Seconds"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "expected_version": {
+            "minimum": 1.0,
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "operator": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AlertOperator"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AlertSeverity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold"
+          },
+          "window": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Window"
+          }
+        },
+        "required": [
+          "expected_version"
+        ],
+        "title": "AlertRuleUpdate",
+        "type": "object"
+      },
+      "AlertSeverity": {
+        "enum": [
+          "warning",
+          "critical"
+        ],
+        "title": "AlertSeverity",
+        "type": "string"
+      },
+      "DeviceCreate": {
+        "properties": {
+          "firmware_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firmware Version"
+          },
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pond_id",
+          "name"
+        ],
+        "title": "DeviceCreate",
+        "type": "object"
+      },
+      "DeviceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DeviceResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "DeviceListResponse",
+        "type": "object"
+      },
+      "DeviceResponse": {
+        "properties": {
+          "auth_type": {
+            "title": "Auth Type",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "device_id": {
+            "title": "Device Id",
+            "type": "string"
+          },
+          "firmware_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firmware Version"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created_at",
+          "updated_at",
+          "version",
+          "status",
+          "tenant_id",
+          "pond_id",
+          "device_id",
+          "name",
+          "auth_type"
+        ],
+        "title": "DeviceResponse",
+        "type": "object"
+      },
+      "DeviceUpdate": {
+        "properties": {
+          "expected_version": {
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "firmware_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firmware Version"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "pond_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pond Id"
+          }
+        },
+        "required": [
+          "expected_version"
+        ],
+        "title": "DeviceUpdate",
+        "type": "object"
+      },
+      "EmailDeliverability": {
+        "enum": [
+          "unknown",
+          "deliverable",
+          "suppressed"
+        ],
+        "title": "EmailDeliverability",
+        "type": "string"
+      },
+      "EmailNotificationPreferenceResponse": {
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "deliverability": {
+            "$ref": "#/components/schemas/EmailDeliverability"
+          },
+          "effective_enabled": {
+            "title": "Effective Enabled",
+            "type": "boolean"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "suppression_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suppression Reason"
+          },
+          "verified": {
+            "title": "Verified",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled",
+          "address",
+          "verified",
+          "deliverability",
+          "suppression_reason",
+          "effective_enabled"
+        ],
+        "title": "EmailNotificationPreferenceResponse",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LatestMetricsResponse": {
+        "properties": {
+          "battery_v": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Battery V"
+          },
+          "do_mg_l": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Do Mg L"
+          },
+          "measured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Measured At"
+          },
+          "ph": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ph"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "rssi": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rssi"
+          },
+          "salinity_ppt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Salinity Ppt"
+          },
+          "seq": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seq"
+          },
+          "temp_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temp C"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "turbidity_ntu": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turbidity Ntu"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "pond_id"
+        ],
+        "title": "LatestMetricsResponse",
+        "type": "object"
+      },
+      "MeResponse": {
+        "properties": {
+          "cognito_sub": {
+            "title": "Cognito Sub",
+            "type": "string"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "groups": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Groups",
+            "type": "array"
+          }
+        },
+        "required": [
+          "cognito_sub"
+        ],
+        "title": "MeResponse",
+        "type": "object"
+      },
+      "NotificationPreferenceResponse": {
+        "properties": {
+          "configured": {
+            "title": "Configured",
+            "type": "boolean"
+          },
+          "email": {
+            "$ref": "#/components/schemas/EmailNotificationPreferenceResponse"
+          },
+          "minimum_severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "telegram": {
+            "$ref": "#/components/schemas/TelegramNotificationPreferenceResponse"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          }
+        },
+        "required": [
+          "configured",
+          "version",
+          "email",
+          "telegram",
+          "minimum_severity"
+        ],
+        "title": "NotificationPreferenceResponse",
+        "type": "object"
+      },
+      "NotificationPreferenceUpdate": {
+        "additionalProperties": false,
+        "properties": {
+          "email_enabled": {
+            "title": "Email Enabled",
+            "type": "boolean"
+          },
+          "expected_version": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Version"
+          },
+          "minimum_severity": {
+            "$ref": "#/components/schemas/AlertSeverity",
+            "default": "critical"
+          },
+          "telegram_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Enabled"
+          }
+        },
+        "required": [
+          "expected_version",
+          "email_enabled"
+        ],
+        "title": "NotificationPreferenceUpdate",
+        "type": "object"
+      },
+      "PondCreate": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "PondCreate",
+        "type": "object"
+      },
+      "PondListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PondResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "PondListResponse",
+        "type": "object"
+      },
+      "PondResponse": {
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created_at",
+          "updated_at",
+          "version",
+          "status",
+          "tenant_id",
+          "pond_id",
+          "name"
+        ],
+        "title": "PondResponse",
+        "type": "object"
+      },
+      "PondUpdate": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "expected_version": {
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "required": [
+          "expected_version"
+        ],
+        "title": "PondUpdate",
+        "type": "object"
+      },
+      "TelegramBindingResponse": {
+        "properties": {
+          "effective_enabled": {
+            "title": "Effective Enabled",
+            "type": "boolean"
+          },
+          "pending_expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Expires At"
+          },
+          "pending_request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Request Id"
+          },
+          "status": {
+            "enum": [
+              "absent",
+              "pending",
+              "verified",
+              "suppressed",
+              "revoked"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "verified_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified At"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          }
+        },
+        "required": [
+          "status",
+          "version",
+          "verified_at",
+          "pending_request_id",
+          "pending_expires_at",
+          "effective_enabled"
+        ],
+        "title": "TelegramBindingResponse",
+        "type": "object"
+      },
+      "TelegramBindingTokenResponse": {
+        "properties": {
+          "deep_link": {
+            "title": "Deep Link",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "request_id",
+          "token",
+          "deep_link",
+          "expires_at"
+        ],
+        "title": "TelegramBindingTokenResponse",
+        "type": "object"
+      },
+      "TelegramNotificationPreferenceResponse": {
+        "properties": {
+          "effective_enabled": {
+            "title": "Effective Enabled",
+            "type": "boolean"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "pending_expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Expires At"
+          },
+          "pending_request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Request Id"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "verified_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified At"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          }
+        },
+        "required": [
+          "enabled",
+          "status",
+          "version",
+          "verified_at",
+          "pending_request_id",
+          "pending_expires_at",
+          "effective_enabled"
+        ],
+        "title": "TelegramNotificationPreferenceResponse",
+        "type": "object"
+      },
+      "TelemetryReadingListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TelemetryReadingResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "TelemetryReadingListResponse",
+        "type": "object"
+      },
+      "TelemetryReadingResponse": {
+        "properties": {
+          "battery_v": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Battery V"
+          },
+          "device_id": {
+            "title": "Device Id",
+            "type": "string"
+          },
+          "do_mg_l": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Do Mg L"
+          },
+          "measured_at": {
+            "title": "Measured At",
+            "type": "string"
+          },
+          "ph": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ph"
+          },
+          "pond_id": {
+            "title": "Pond Id",
+            "type": "string"
+          },
+          "rssi": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rssi"
+          },
+          "salinity_ppt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Salinity Ppt"
+          },
+          "seq": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seq"
+          },
+          "temp_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temp C"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "turbidity_ntu": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turbidity Ntu"
+          }
+        },
+        "required": [
+          "measured_at",
+          "tenant_id",
+          "pond_id",
+          "device_id"
+        ],
+        "title": "TelemetryReadingResponse",
+        "type": "object"
+      },
+      "TenantCreate": {
+        "properties": {
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "TenantCreate",
+        "type": "object"
+      },
+      "TenantListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TenantResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "TenantListResponse",
+        "type": "object"
+      },
+      "TenantResponse": {
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created_at",
+          "updated_at",
+          "version",
+          "status",
+          "tenant_id",
+          "name"
+        ],
+        "title": "TenantResponse",
+        "type": "object"
+      },
+      "TenantUpdate": {
+        "properties": {
+          "expected_version": {
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "required": [
+          "expected_version"
+        ],
+        "title": "TenantUpdate",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Limnopulse API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/me": {
+      "get": {
+        "operationId": "get_me_v1_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Me",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/v1/tenants": {
+      "get": {
+        "operationId": "list_tenants_v1_tenants_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Tenants",
+        "tags": [
+          "tenants"
+        ]
+      },
+      "post": {
+        "operationId": "create_tenant_v1_tenants_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Create Tenant",
+        "tags": [
+          "tenants"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}": {
+      "get": {
+        "operationId": "get_tenant_v1_tenants__tenant_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Tenant",
+        "tags": [
+          "tenants"
+        ]
+      },
+      "patch": {
+        "operationId": "update_tenant_v1_tenants__tenant_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Update Tenant",
+        "tags": [
+          "tenants"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-events": {
+      "get": {
+        "operationId": "list_alert_events_v1_tenants__tenant_id__alert_events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertEventListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Alert Events",
+        "tags": [
+          "alert-events"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-events/{event_id}": {
+      "get": {
+        "operationId": "get_alert_event_v1_tenants__tenant_id__alert_events__event_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Alert Event",
+        "tags": [
+          "alert-events"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-events/{event_id}/acknowledge": {
+      "post": {
+        "operationId": "acknowledge_alert_event_v1_tenants__tenant_id__alert_events__event_id__acknowledge_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertEventTransitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Acknowledge Alert Event",
+        "tags": [
+          "alert-events"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-events/{event_id}/resolve": {
+      "post": {
+        "operationId": "resolve_alert_event_v1_tenants__tenant_id__alert_events__event_id__resolve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertEventTransitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Alert Event",
+        "tags": [
+          "alert-events"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-rules": {
+      "get": {
+        "operationId": "list_alert_rules_v1_tenants__tenant_id__alert_rules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List Alert Rules",
+        "tags": [
+          "alert-rules"
+        ]
+      },
+      "post": {
+        "operationId": "create_alert_rule_v1_tenants__tenant_id__alert_rules_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Create Alert Rule",
+        "tags": [
+          "alert-rules"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-rules/{rule_id}": {
+      "patch": {
+        "operationId": "update_alert_rule_v1_tenants__tenant_id__alert_rules__rule_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Update Alert Rule",
+        "tags": [
+          "alert-rules"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/alert-rules/{rule_id}/replace": {
+      "post": {
+        "operationId": "replace_alert_rule_v1_tenants__tenant_id__alert_rules__rule_id__replace_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": true,
+            "schema": {
+              "maxLength": 128,
+              "minLength": 8,
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleReplace"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleReplacementResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Replace Alert Rule",
+        "tags": [
+          "alert-rules"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/devices": {
+      "get": {
+        "operationId": "list_devices_v1_tenants__tenant_id__devices_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List Devices",
+        "tags": [
+          "devices"
+        ]
+      },
+      "post": {
+        "operationId": "create_device_v1_tenants__tenant_id__devices_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Create Device",
+        "tags": [
+          "devices"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/devices/{device_id}": {
+      "get": {
+        "operationId": "get_device_v1_tenants__tenant_id__devices__device_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "device_id",
+            "required": true,
+            "schema": {
+              "title": "Device Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Device",
+        "tags": [
+          "devices"
+        ]
+      },
+      "patch": {
+        "operationId": "update_device_v1_tenants__tenant_id__devices__device_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "device_id",
+            "required": true,
+            "schema": {
+              "title": "Device Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Update Device",
+        "tags": [
+          "devices"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/me/notification-preferences": {
+      "get": {
+        "operationId": "get_notification_preferences_v1_tenants__tenant_id__me_notification_preferences_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Notification Preferences",
+        "tags": [
+          "notification-preferences"
+        ]
+      },
+      "put": {
+        "operationId": "put_notification_preferences_v1_tenants__tenant_id__me_notification_preferences_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationPreferenceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Put Notification Preferences",
+        "tags": [
+          "notification-preferences"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/me/telegram-binding": {
+      "delete": {
+        "operationId": "delete_telegram_binding_v1_tenants__tenant_id__me_telegram_binding_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Telegram Binding",
+        "tags": [
+          "telegram-bindings"
+        ]
+      },
+      "get": {
+        "operationId": "get_telegram_binding_v1_tenants__tenant_id__me_telegram_binding_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelegramBindingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Telegram Binding",
+        "tags": [
+          "telegram-bindings"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/me/telegram-binding-token": {
+      "post": {
+        "operationId": "create_telegram_binding_token_v1_tenants__tenant_id__me_telegram_binding_token_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelegramBindingTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Telegram Binding Token",
+        "tags": [
+          "telegram-bindings"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/ponds": {
+      "get": {
+        "operationId": "list_ponds_v1_tenants__tenant_id__ponds_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PondListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List Ponds",
+        "tags": [
+          "ponds"
+        ]
+      },
+      "post": {
+        "operationId": "create_pond_v1_tenants__tenant_id__ponds_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PondCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PondResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Create Pond",
+        "tags": [
+          "ponds"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/ponds/{pond_id}": {
+      "get": {
+        "operationId": "get_pond_v1_tenants__tenant_id__ponds__pond_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pond_id",
+            "required": true,
+            "schema": {
+              "title": "Pond Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PondResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Pond",
+        "tags": [
+          "ponds"
+        ]
+      },
+      "patch": {
+        "operationId": "update_pond_v1_tenants__tenant_id__ponds__pond_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pond_id",
+            "required": true,
+            "schema": {
+              "title": "Pond Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PondUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PondResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Update Pond",
+        "tags": [
+          "ponds"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/ponds/{pond_id}/metrics/latest": {
+      "get": {
+        "operationId": "query_latest_metrics_v1_tenants__tenant_id__ponds__pond_id__metrics_latest_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pond_id",
+            "required": true,
+            "schema": {
+              "title": "Pond Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LatestMetricsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Query Latest Metrics",
+        "tags": [
+          "telemetry"
+        ]
+      }
+    },
+    "/v1/tenants/{tenant_id}/ponds/{pond_id}/readings": {
+      "get": {
+        "operationId": "query_readings_v1_tenants__tenant_id__ponds__pond_id__readings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pond_id",
+            "required": true,
+            "schema": {
+              "title": "Pond Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start",
+            "required": false,
+            "schema": {
+              "default": "-1h",
+              "title": "Start",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "stop",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Stop"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelemetryReadingListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Query Readings",
+        "tags": [
+          "telemetry"
+        ]
+      }
+    }
+  }
+}

--- a/tests/contracts/test_v1_openapi_contract.py
+++ b/tests/contracts/test_v1_openapi_contract.py
@@ -39,6 +39,18 @@ def test_v1_openapi_normalizes_only_framework_default_422_description() -> None:
         return {"ok": True}
 
     @app.put(
+        "/v1/collision",
+        responses={
+            422: {
+                "model": ErrorResponse,
+                "description": "Unprocessable Content",
+            }
+        },
+    )
+    async def collision_response() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.put(
         "/v1/other-schema",
         responses={
             422: {
@@ -60,6 +72,9 @@ def test_v1_openapi_normalizes_only_framework_default_422_description() -> None:
     )
     assert actual["paths"]["/v1/custom"]["put"]["responses"]["422"]["description"] == (
         "Verified email required"
+    )
+    assert actual["paths"]["/v1/collision"]["put"]["responses"]["422"]["description"] == (
+        "Unprocessable Content"
     )
     assert actual["paths"]["/v1/other-schema"]["put"]["responses"]["422"][
         "description"

--- a/tests/contracts/test_v1_openapi_contract.py
+++ b/tests/contracts/test_v1_openapi_contract.py
@@ -1,8 +1,13 @@
+import importlib
 import json
 from pathlib import Path
+from typing import Annotated
 
-from fastapi import FastAPI
+import fastapi.routing as fastapi_routing
+from fastapi import FastAPI, Security
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 
+from limnopulse_api.api import openapi_contract
 from limnopulse_api.api.openapi_contract import build_v1_openapi_contract
 from limnopulse_api.api.v1.schemas.common import ErrorResponse
 from limnopulse_api.core.config import Settings
@@ -80,3 +85,49 @@ def test_v1_openapi_normalizes_only_framework_default_422_description() -> None:
         "description"
     ] == "Unprocessable Content"
     assert source_schema == source_snapshot
+
+
+def test_effective_api_routes_fall_back_without_route_context_helper(
+    monkeypatch,
+) -> None:
+    app = FastAPI()
+
+    @app.get("/v1/items/{item_id}")
+    async def get_item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    with monkeypatch.context() as patch:
+        patch.delattr(fastapi_routing, "iter_route_contexts", raising=False)
+        compatibility_module = importlib.reload(openapi_contract)
+        routes = list(compatibility_module.iter_effective_api_routes(app))
+
+    assert [(route.path_format, route.methods) for route in routes] == [
+        ("/v1/items/{item_id}", {"GET"})
+    ]
+
+
+def test_v1_openapi_keeps_only_security_schemes_used_by_v1_operations() -> None:
+    app = FastAPI()
+    used_bearer = HTTPBearer(scheme_name="UsedBearer")
+    unused_key = APIKeyHeader(name="X-Unused-Key", scheme_name="UnusedKey")
+
+    @app.get("/v1/secure")
+    async def secure(
+        credentials: Annotated[HTTPAuthorizationCredentials, Security(used_bearer)],
+    ) -> dict[str, str]:
+        return {"scheme": credentials.scheme}
+
+    @app.get("/internal/secure")
+    async def internal_secure(
+        key: Annotated[str, Security(unused_key)],
+    ) -> dict[str, str]:
+        return {"key": key}
+
+    actual = build_v1_openapi_contract(app)
+
+    assert actual["paths"]["/v1/secure"]["get"]["security"] == [
+        {"UsedBearer": []}
+    ]
+    assert actual["components"]["securitySchemes"] == {
+        "UsedBearer": {"scheme": "bearer", "type": "http"}
+    }

--- a/tests/contracts/test_v1_openapi_contract.py
+++ b/tests/contracts/test_v1_openapi_contract.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from limnopulse_api.api.openapi_contract import build_v1_openapi_contract
+from limnopulse_api.api.v1.schemas.common import ErrorResponse
+from limnopulse_api.core.config import Settings
+from limnopulse_api.main import create_app
+
+ROOT = Path(__file__).resolve().parents[2]
+GOLDEN = ROOT / "tests/contracts/openapi/v1.json"
+
+
+def test_v1_openapi_matches_checked_in_golden() -> None:
+    app = create_app(Settings(app_env="test", auth_mode="dev"))
+    actual = build_v1_openapi_contract(app)
+    assert all(path.startswith("/v1/") for path in actual["paths"])
+    assert actual == json.loads(GOLDEN.read_text(encoding="utf-8"))
+
+
+def test_v1_openapi_normalizes_only_framework_default_422_description() -> None:
+    app = FastAPI()
+
+    @app.put("/v1/default", responses={422: {"model": ErrorResponse}})
+    async def default_response() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.put(
+        "/v1/custom",
+        responses={
+            422: {
+                "model": ErrorResponse,
+                "description": "Verified email required",
+            }
+        },
+    )
+    async def custom_response() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.put(
+        "/v1/other-schema",
+        responses={
+            422: {
+                "model": dict[str, str],
+                "description": "Unprocessable Content",
+            }
+        },
+    )
+    async def other_schema_response() -> dict[str, bool]:
+        return {"ok": True}
+
+    source_schema = app.openapi()
+    source_snapshot = json.loads(json.dumps(source_schema))
+
+    actual = build_v1_openapi_contract(app)
+
+    assert actual["paths"]["/v1/default"]["put"]["responses"]["422"]["description"] == (
+        "Unprocessable Entity"
+    )
+    assert actual["paths"]["/v1/custom"]["put"]["responses"]["422"]["description"] == (
+        "Verified email required"
+    )
+    assert actual["paths"]["/v1/other-schema"]["put"]["responses"]["422"][
+        "description"
+    ] == "Unprocessable Content"
+    assert source_schema == source_snapshot

--- a/tests/unit/test_no_scan_guard.py
+++ b/tests/unit/test_no_scan_guard.py
@@ -6,8 +6,9 @@ ROOT = Path(__file__).resolve().parents[2]
 DYNAMODB_IMPORT_PATH = "github.com/aws/aws-sdk-go-v2/service/dynamodb"
 DYNAMODB_IMPORT_MARKER = "__DYNAMODB_IMPORT__"
 GO_SCAN_METHOD_CALL = re.compile(r"\.\s*Scan\s*\(")
-GO_UNQUALIFIED_SCAN_PAGINATOR_CALL = re.compile(
-    r"(?<![.A-Za-z0-9_])NewScanPaginator\s*\("
+GO_SCAN_PAGINATOR_CALL = re.compile(r"\bNewScanPaginator\s*\(")
+GO_PAGINATOR_DECLARATION_PREFIX = re.compile(
+    r"\bfunc(?:\s*\([^)]*\))?\s*$"
 )
 GO_TOKEN = re.compile(
     r"(?P<line_comment>//[^\n]*)"
@@ -76,6 +77,17 @@ def _dynamodb_import_aliases(source: str) -> set[str]:
     return aliases
 
 
+def _has_unqualified_scan_paginator_call(code: str) -> bool:
+    for match in GO_SCAN_PAGINATOR_CALL.finditer(code):
+        prefix = code[: match.start()]
+        if re.search(r"\.\s*$", prefix):
+            continue
+        if GO_PAGINATOR_DECLARATION_PREFIX.search(prefix):
+            continue
+        return True
+    return False
+
+
 def _has_go_scan_call(source: str) -> bool:
     aliases = _dynamodb_import_aliases(_go_import_structure(source))
     code = GO_TOKEN.sub(lambda match: _blank_go_token(match.group()), source)
@@ -87,7 +99,7 @@ def _has_go_scan_call(source: str) -> bool:
         bool(GO_SCAN_METHOD_CALL.search(code))
         or (
             "." in aliases
-            and bool(GO_UNQUALIFIED_SCAN_PAGINATOR_CALL.search(code))
+            and _has_unqualified_scan_paginator_call(code)
         )
         or qualified_paginator_call
     )
@@ -182,6 +194,47 @@ def test_go_offenders_detect_scan_paginator_dot_import(tmp_path, monkeypatch) ->
     (root / "store_test.go").write_text(source, encoding="utf-8")
 
     assert go_offenders(root) == ["internal/store.go"]
+
+
+def test_go_offenders_ignore_local_paginator_method_with_dot_import(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        'import . "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        "var _ Client\n"
+        "type local struct{}\n"
+        "func (local) NewScanPaginator() {}\n"
+    )
+    (root / "allowed.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == []
+
+
+def test_go_offenders_ignore_other_package_paginator_selectors_with_dot_import(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        "import (\n"
+        '    . "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        '    other "example.com/other"\n'
+        ")\n"
+        "var _ Client\n"
+        "func f() {\n"
+        "    other . NewScanPaginator(nil, nil)\n"
+        "    other./* qualifier */NewScanPaginator(nil, nil)\n"
+        "}\n"
+    )
+    (root / "allowed.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == []
 
 
 def test_go_offenders_ignore_dynamodb_import_fabricated_by_raw_string(

--- a/tests/unit/test_no_scan_guard.py
+++ b/tests/unit/test_no_scan_guard.py
@@ -3,7 +3,9 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-GO_SCAN_CALL = re.compile(r"\.\s*Scan\s*\(")
+GO_SCAN_CALL = re.compile(
+    r"(?:\.\s*Scan\s*\(|\bdynamodb\s*\.\s*NewScanPaginator\s*\()"
+)
 
 
 def python_offenders(root: Path) -> list[str]:
@@ -44,6 +46,22 @@ def test_go_offenders_detect_scan_calls_but_exclude_test_files(tmp_path, monkeyp
     root = tmp_path / "internal"
     root.mkdir()
     source = "package store\nfunc f(client Client) { client . Scan (nil) }\n"
+    (root / "store.go").write_text(source, encoding="utf-8")
+    (root / "store_test.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == ["internal/store.go"]
+
+
+def test_go_offenders_detect_scan_paginator_but_exclude_test_files(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        "func f(client *dynamodb.Client) { dynamodb.NewScanPaginator(client, nil) }\n"
+    )
     (root / "store.go").write_text(source, encoding="utf-8")
     (root / "store_test.go").write_text(source, encoding="utf-8")
 

--- a/tests/unit/test_no_scan_guard.py
+++ b/tests/unit/test_no_scan_guard.py
@@ -3,7 +3,12 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+DYNAMODB_IMPORT_PATH = "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+DYNAMODB_IMPORT_MARKER = "__DYNAMODB_IMPORT__"
 GO_SCAN_METHOD_CALL = re.compile(r"\.\s*Scan\s*\(")
+GO_UNQUALIFIED_SCAN_PAGINATOR_CALL = re.compile(
+    r"(?<![.A-Za-z0-9_])NewScanPaginator\s*\("
+)
 GO_TOKEN = re.compile(
     r"(?P<line_comment>//[^\n]*)"
     r"|(?P<block_comment>/\*.*?\*/)"
@@ -14,13 +19,13 @@ GO_TOKEN = re.compile(
 )
 GO_IMPORT_BLOCK = re.compile(r"\bimport\s*\((?P<body>.*?)\)", re.DOTALL)
 GO_DYNAMODB_IMPORT_SPEC = re.compile(
-    r'^\s*(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s+)?'
-    r'["`]github\.com/aws/aws-sdk-go-v2/service/dynamodb["`]\s*$',
+    rf"^\s*(?:(?P<alias>\.|[A-Za-z_][A-Za-z0-9_]*)\s+)?"
+    rf"{DYNAMODB_IMPORT_MARKER}\s*$",
     re.MULTILINE,
 )
 GO_DYNAMODB_SINGLE_IMPORT = re.compile(
-    r'^\s*import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s+)?'
-    r'["`]github\.com/aws/aws-sdk-go-v2/service/dynamodb["`]\s*$',
+    rf"^\s*import\s+(?:(?P<alias>\.|[A-Za-z_][A-Za-z0-9_]*)\s+)?"
+    rf"{DYNAMODB_IMPORT_MARKER}\s*$",
     re.MULTILINE,
 )
 
@@ -43,12 +48,13 @@ def _blank_go_token(value: str) -> str:
     return "".join("\n" if char == "\n" else " " for char in value)
 
 
-def _without_go_comments(source: str) -> str:
+def _go_import_structure(source: str) -> str:
     return GO_TOKEN.sub(
         lambda match: (
-            _blank_go_token(match.group())
-            if match.lastgroup in {"line_comment", "block_comment"}
-            else match.group()
+            DYNAMODB_IMPORT_MARKER
+            if match.lastgroup in {"string", "raw_string"}
+            and match.group()[1:-1] == DYNAMODB_IMPORT_PATH
+            else _blank_go_token(match.group())
         ),
         source,
     )
@@ -71,12 +77,19 @@ def _dynamodb_import_aliases(source: str) -> set[str]:
 
 
 def _has_go_scan_call(source: str) -> bool:
-    source_without_comments = _without_go_comments(source)
-    aliases = _dynamodb_import_aliases(source_without_comments)
+    aliases = _dynamodb_import_aliases(_go_import_structure(source))
     code = GO_TOKEN.sub(lambda match: _blank_go_token(match.group()), source)
-    return bool(GO_SCAN_METHOD_CALL.search(code)) or any(
+    qualified_paginator_call = any(
         re.search(rf"\b{re.escape(alias)}\s*\.\s*NewScanPaginator\s*\(", code)
-        for alias in aliases
+        for alias in aliases - {"."}
+    )
+    return (
+        bool(GO_SCAN_METHOD_CALL.search(code))
+        or (
+            "." in aliases
+            and bool(GO_UNQUALIFIED_SCAN_PAGINATOR_CALL.search(code))
+        )
+        or qualified_paginator_call
     )
 
 
@@ -154,6 +167,40 @@ def test_go_offenders_detect_scan_paginator_import_alias_without_comments(
     (root / "store_test.go").write_text(source, encoding="utf-8")
 
     assert go_offenders(root) == ["internal/store.go"]
+
+
+def test_go_offenders_detect_scan_paginator_dot_import(tmp_path, monkeypatch) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        'import . "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        "func f(client *Client) { NewScanPaginator(client, nil) }\n"
+    )
+    (root / "store.go").write_text(source, encoding="utf-8")
+    (root / "store_test.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == ["internal/store.go"]
+
+
+def test_go_offenders_ignore_dynamodb_import_fabricated_by_raw_string(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        'import ddb "example.com/not-dynamodb"\n'
+        "var example = `\n"
+        'import ddb "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        "`\n"
+        "func f() { ddb.NewScanPaginator(nil, nil) }\n"
+    )
+    (root / "allowed.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == []
 
 
 def test_no_dynamodb_scan_in_application_code() -> None:

--- a/tests/unit/test_no_scan_guard.py
+++ b/tests/unit/test_no_scan_guard.py
@@ -1,11 +1,60 @@
+import ast
+import re
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GO_SCAN_CALL = re.compile(r"\.\s*Scan\s*\(")
+
+
+def python_offenders(root: Path) -> list[str]:
+    offenders: list[str] = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "scan"
+            for node in ast.walk(tree)
+        ):
+            offenders.append(str(path.relative_to(ROOT)))
+    return offenders
+
+
+def go_offenders(root: Path) -> list[str]:
+    return [
+        str(path.relative_to(ROOT))
+        for path in root.rglob("*.go")
+        if not path.name.endswith("_test.go")
+        and GO_SCAN_CALL.search(path.read_text(encoding="utf-8"))
+    ]
+
+
+def test_python_offenders_detect_only_scan_attribute_calls(tmp_path, monkeypatch) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "src"
+    root.mkdir()
+    (root / "offender.py").write_text("client . scan ({} )\n", encoding="utf-8")
+    (root / "allowed.py").write_text("scan()\nclient.Scan()\n", encoding="utf-8")
+
+    assert python_offenders(root) == ["src/offender.py"]
+
+
+def test_go_offenders_detect_scan_calls_but_exclude_test_files(tmp_path, monkeypatch) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = "package store\nfunc f(client Client) { client . Scan (nil) }\n"
+    (root / "store.go").write_text(source, encoding="utf-8")
+    (root / "store_test.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == ["internal/store.go"]
 
 
 def test_no_dynamodb_scan_in_application_code() -> None:
-    root = Path("src/limnopulse_api")
-    offenders = []
-    for path in root.rglob("*.py"):
-        text = path.read_text()
-        if ".scan(" in text or "scan(" in text:
-            offenders.append(str(path))
+    offenders = (
+        python_offenders(ROOT / "src")
+        + python_offenders(ROOT / "scripts")
+        + go_offenders(ROOT / "cmd")
+        + go_offenders(ROOT / "internal")
+    )
     assert offenders == []

--- a/tests/unit/test_no_scan_guard.py
+++ b/tests/unit/test_no_scan_guard.py
@@ -3,8 +3,25 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-GO_SCAN_CALL = re.compile(
-    r"(?:\.\s*Scan\s*\(|\bdynamodb\s*\.\s*NewScanPaginator\s*\()"
+GO_SCAN_METHOD_CALL = re.compile(r"\.\s*Scan\s*\(")
+GO_TOKEN = re.compile(
+    r"(?P<line_comment>//[^\n]*)"
+    r"|(?P<block_comment>/\*.*?\*/)"
+    r"|(?P<raw_string>`[^`]*`)"
+    r'|(?P<string>"(?:\\.|[^"\\])*")'
+    r"|(?P<rune>'(?:\\.|[^'\\])*')",
+    re.DOTALL,
+)
+GO_IMPORT_BLOCK = re.compile(r"\bimport\s*\((?P<body>.*?)\)", re.DOTALL)
+GO_DYNAMODB_IMPORT_SPEC = re.compile(
+    r'^\s*(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s+)?'
+    r'["`]github\.com/aws/aws-sdk-go-v2/service/dynamodb["`]\s*$',
+    re.MULTILINE,
+)
+GO_DYNAMODB_SINGLE_IMPORT = re.compile(
+    r'^\s*import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s+)?'
+    r'["`]github\.com/aws/aws-sdk-go-v2/service/dynamodb["`]\s*$',
+    re.MULTILINE,
 )
 
 
@@ -22,12 +39,53 @@ def python_offenders(root: Path) -> list[str]:
     return offenders
 
 
+def _blank_go_token(value: str) -> str:
+    return "".join("\n" if char == "\n" else " " for char in value)
+
+
+def _without_go_comments(source: str) -> str:
+    return GO_TOKEN.sub(
+        lambda match: (
+            _blank_go_token(match.group())
+            if match.lastgroup in {"line_comment", "block_comment"}
+            else match.group()
+        ),
+        source,
+    )
+
+
+def _dynamodb_import_aliases(source: str) -> set[str]:
+    aliases: set[str] = set()
+
+    def add_alias(match: re.Match[str]) -> None:
+        alias = match.group("alias") or "dynamodb"
+        if alias != "_":
+            aliases.add(alias)
+
+    for match in GO_DYNAMODB_SINGLE_IMPORT.finditer(source):
+        add_alias(match)
+    for block in GO_IMPORT_BLOCK.finditer(source):
+        for match in GO_DYNAMODB_IMPORT_SPEC.finditer(block.group("body")):
+            add_alias(match)
+    return aliases
+
+
+def _has_go_scan_call(source: str) -> bool:
+    source_without_comments = _without_go_comments(source)
+    aliases = _dynamodb_import_aliases(source_without_comments)
+    code = GO_TOKEN.sub(lambda match: _blank_go_token(match.group()), source)
+    return bool(GO_SCAN_METHOD_CALL.search(code)) or any(
+        re.search(rf"\b{re.escape(alias)}\s*\.\s*NewScanPaginator\s*\(", code)
+        for alias in aliases
+    )
+
+
 def go_offenders(root: Path) -> list[str]:
     return [
         str(path.relative_to(ROOT))
         for path in root.rglob("*.go")
         if not path.name.endswith("_test.go")
-        and GO_SCAN_CALL.search(path.read_text(encoding="utf-8"))
+        and _has_go_scan_call(path.read_text(encoding="utf-8"))
     ]
 
 
@@ -60,9 +118,39 @@ def test_go_offenders_detect_scan_paginator_but_exclude_test_files(
     root.mkdir()
     source = (
         "package store\n"
+        'import "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
         "func f(client *dynamodb.Client) { dynamodb.NewScanPaginator(client, nil) }\n"
     )
     (root / "store.go").write_text(source, encoding="utf-8")
+    (root / "store_test.go").write_text(source, encoding="utf-8")
+
+    assert go_offenders(root) == ["internal/store.go"]
+
+
+def test_go_offenders_detect_scan_paginator_import_alias_without_comments(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(globals(), "ROOT", tmp_path)
+    root = tmp_path / "internal"
+    root.mkdir()
+    source = (
+        "package store\n"
+        "import (\n"
+        '    ddb "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        ")\n"
+        "func f(client *ddb.Client) { ddb.NewScanPaginator(client, nil) }\n"
+    )
+    allowed = (
+        "package store\n"
+        "import (\n"
+        '    ddb "github.com/aws/aws-sdk-go-v2/service/dynamodb"\n'
+        ")\n"
+        "// ddb.NewScanPaginator(client, nil)\n"
+        "/* ddb.NewScanPaginator(client, nil) */\n"
+        'var example = "ddb.NewScanPaginator(client, nil)"\n'
+    )
+    (root / "store.go").write_text(source, encoding="utf-8")
+    (root / "allowed.go").write_text(allowed, encoding="utf-8")
     (root / "store_test.go").write_text(source, encoding="utf-8")
 
     assert go_offenders(root) == ["internal/store.go"]

--- a/tests/unit/test_tenant_mapping_conformance.py
+++ b/tests/unit/test_tenant_mapping_conformance.py
@@ -1,0 +1,33 @@
+from fastapi.routing import APIRoute, iter_route_contexts
+
+from limnopulse_api.adapters.dynamodb import DynamoKeyBuilder
+from limnopulse_api.api.dependencies import require_tenant_access
+from limnopulse_api.core.config import Settings
+from limnopulse_api.main import create_app
+
+
+def dependency_calls(dependant):
+    yield dependant.call
+    for dependency in dependant.dependencies:
+        yield from dependency_calls(dependency)
+
+
+def test_every_mounted_tenant_route_requires_membership() -> None:
+    app = create_app(Settings(app_env="test", auth_mode="dev"))
+    routes = [
+        context
+        for context in iter_route_contexts(app.routes)
+        if isinstance(context.original_route, APIRoute)
+        and context.path_format is not None
+        and "{tenant_id}" in context.path_format
+    ]
+    assert routes
+    for route in routes:
+        assert require_tenant_access in set(dependency_calls(route.dependant))
+
+
+def test_legacy_tenant_keys_cannot_cross_partitions() -> None:
+    keys = DynamoKeyBuilder()
+    assert keys.pond("tnt_a", "pond_1")["PK"] == "TENANT#tnt_a"
+    assert keys.device("tnt_a", "dev_1") != keys.device("tnt_b", "dev_1")
+    assert keys.membership("sub_1", "tnt_a")["SK"] == "TENANT#tnt_a"

--- a/tests/unit/test_tenant_mapping_conformance.py
+++ b/tests/unit/test_tenant_mapping_conformance.py
@@ -1,7 +1,6 @@
-from fastapi.routing import APIRoute, iter_route_contexts
-
 from limnopulse_api.adapters.dynamodb import DynamoKeyBuilder
 from limnopulse_api.api.dependencies import require_tenant_access
+from limnopulse_api.api.openapi_contract import iter_effective_api_routes
 from limnopulse_api.core.config import Settings
 from limnopulse_api.main import create_app
 
@@ -15,13 +14,11 @@ def dependency_calls(dependant):
 def test_every_mounted_tenant_route_requires_membership() -> None:
     app = create_app(Settings(app_env="test", auth_mode="dev"))
     routes = [
-        context
-        for context in iter_route_contexts(app.routes)
-        if isinstance(context.original_route, APIRoute)
-        and context.path_format is not None
-        and "{tenant_id}" in context.path_format
+        route
+        for route in iter_effective_api_routes(app)
+        if "{tenant_id}" in route.path_format
     ]
-    assert routes
+    assert len(routes) == 25
     for route in routes:
         assert require_tenant_access in set(dependency_calls(route.dependant))
 


### PR DESCRIPTION
## Summary

- freezes the actual mounted `/v1` OpenAPI surface as a deterministic checked-in golden
- exports only `/v1` paths and recursively reachable OpenAPI components
- proves all 25 effective tenant route operations transitively require membership authorization
- preserves legacy tenant-scoped key isolation
- upgrades the no-Scan guard to Python AST and Go call detection
- normalizes only FastAPI-generated implicit 422 status synonyms across Python 3.12/3.14 while preserving explicit descriptions

Closes #29

## Scope and ownership

Exactly the six Issue #29-owned paths change:

- `src/limnopulse_api/api/openapi_contract.py`
- `scripts/dev/export_v1_openapi.py`
- `tests/contracts/openapi/v1.json`
- `tests/contracts/test_v1_openapi_contract.py`
- `tests/unit/test_tenant_mapping_conformance.py`
- `tests/unit/test_no_scan_guard.py`

The branch was rebased without conflict onto `main@bd6e579a20017f769c6f041bdfde35cb67b30c93` after #27 merged.

## Explicit exclusions

- no route, request, response, status-code, role-gate, service, adapter, or application-composition changes
- no dependency or lockfile changes
- no health or public webhook paths in the golden
- no deployment, infrastructure apply, or external service startup

## TDD evidence

### Golden RED → GREEN

```bash
rtk uv run --locked --extra dev pytest -q tests/contracts/test_v1_openapi_contract.py
```

1. RED: exit 2 with `ModuleNotFoundError: limnopulse_api.api.openapi_contract`.
2. After the helper only, RED: exit 1 with missing `tests/contracts/openapi/v1.json`.
3. After the exporter/golden, GREEN: 1 passed; exporter `--check` exit 0.

### Architecture characterization

- Effective FastAPI 0.141.1 route contexts discover 25 tenant operations; all include `require_tenant_access` transitively.
- Temporarily bypassing `TenantAccessDep` made the membership test fail; restoring it returned GREEN.
- Temporarily removing the tenant from the legacy device partition made the key-isolation test fail; restoring it returned GREEN.
- Synthetic scan helper tests first failed with missing `python_offenders`/`go_offenders`, then all three scan tests passed after the AST/Go implementation.

### Cross-version normalization and review fix

The initial Python 3.12 check exposed one stdlib-derived difference:

```text
/paths/~1v1~1tenants~1{tenant_id}~1me~1notification-preferences/put/responses/422/description
Python 3.12: Unprocessable Entity
Python 3.14: Unprocessable Content
```

FastAPI 0.141.1 falls back to `http.client.responses[422]` when an additional response omits a description. The contract now canonicalizes only copied `/v1` operations whose effective `APIRoute.responses[422]` metadata omits `description`, whose rendered description is one of those two known synonyms, and whose schema is exactly `#/components/schemas/ErrorResponse`.

Review round 1 added an explicit collision case:

```python
responses={422: {"model": ErrorResponse, "description": "Unprocessable Content"}}
```

RED on the previous head: exit 1 because it was rewritten to `Unprocessable Entity`. GREEN after the provenance-aware fix: the explicit phrase remains unchanged, other custom descriptions remain unchanged, non-`ErrorResponse` schemas remain unchanged, and `app.openapi_schema` is not mutated.

## Verification after rebase

Python 3.14 focused gate:

```bash
rtk uv run --python 3.14 --locked --extra dev pytest -q \
  tests/contracts/test_v1_openapi_contract.py \
  tests/unit/test_tenant_mapping_conformance.py \
  tests/unit/test_no_scan_guard.py
rtk uv run --python 3.14 --locked --extra dev python scripts/dev/export_v1_openapi.py --check
```

Result: exit 0; `7 passed in 2.38s`; exporter check exit 0.

Python 3.12 focused gate:

```bash
rtk uv run --python 3.12 --locked --extra dev pytest -q \
  tests/contracts/test_v1_openapi_contract.py \
  tests/unit/test_tenant_mapping_conformance.py \
  tests/unit/test_no_scan_guard.py
rtk uv run --python 3.12 --locked --extra dev python scripts/dev/export_v1_openapi.py --check
```

Result: exit 0; `7 passed in 2.12s`; exporter check exit 0.

Cross-version byte check:

```bash
rtk sha256sum tests/contracts/openapi/v1.json \
  /tmp/limnopulse-v1-rebase-py312.json \
  /tmp/limnopulse-v1-rebase-py314.json
rtk cmp -s /tmp/limnopulse-v1-rebase-py312.json \
  /tmp/limnopulse-v1-rebase-py314.json
```

Result: exit 0; all three SHA-256 values are `3bc972b283e83602fc87e1540b7a144e302d168f0e3ab0d2ba81069ebc855d0d`.

Merged #27 aggregate verification:

```bash
rtk make verify
```

Result: exit 0.

- `uv lock --check`: exit 0
- locked dev sync: exit 0
- Python: `345 passed, 5 skipped, 1 warning in 4.94s`
- `go test -race ./...`: exit 0 across all packages
- OpenTofu backend-disabled init/fmt/validate: exit 0
- `docker compose config --quiet`: exit 0

Diff and ownership:

```bash
rtk git diff --check origin/main...HEAD
rtk git diff --name-status origin/main...HEAD
```

Result: exit 0; exactly the six owned paths listed above.

## Risks and warnings

- The one warning is pre-existing: FastAPI TestClient reports Starlette's `httpx` integration is deprecated in favor of `httpx2`.
- The Go regex is deliberately conservative and can flag `.Scan(` in comments/strings; current application code has no false positive.
- A future third Python status phrase will fail cross-version checking and require explicit review rather than being silently normalized.
- OpenAPI remains intentionally sensitive to all non-approved FastAPI/Pydantic schema drift.

## Rollback

Revert the three branch commits. The helper, exporter, golden, and conformance tests are removed together; runtime routing and persistence behavior are unchanged.

## Review status

This PR is intentionally **draft**. Do not mark ready or merge until review and required CI complete.

## Codex review fix round 2

Commit: `87c2ef5da98845123219146d2fa985a6c3c6f989`

- Removed the unconditional `iter_route_contexts` import. `iter_effective_api_routes()` uses FastAPI's helper when present and falls back to eager top-level `APIRoute` objects for the declared FastAPI 0.115 lower bound. Tenant conformance now consumes this abstraction and still proves exactly 25 effective tenant operations.
- Added operation-security reachability. Named schemes used by selected `/v1` operations are retained, their component `$ref`s remain transitively traversed, and schemes used only outside `/v1` are excluded.
- Extended the Go no-Scan guard to reject AWS SDK v2 `dynamodb.NewScanPaginator(` construction outside `_test.go` files.

RED evidence on the preceding head:

```text
fallback/no-helper: ImportError for fastapi.routing.iter_route_contexts; 1 failed in 0.73s
security dependency: KeyError 'securitySchemes'; 1 failed in 0.73s
NewScanPaginator: expected internal/store.go, got []; 1 failed in 0.04s
```

GREEN evidence:

```bash
rtk uv run --python 3.12 --locked --extra dev pytest -q \
  tests/contracts/test_v1_openapi_contract.py \
  tests/unit/test_tenant_mapping_conformance.py \
  tests/unit/test_no_scan_guard.py
rtk uv run --python 3.12 --locked --extra dev python scripts/dev/export_v1_openapi.py --check

rtk uv run --python 3.14 --locked --extra dev pytest -q \
  tests/contracts/test_v1_openapi_contract.py \
  tests/unit/test_tenant_mapping_conformance.py \
  tests/unit/test_no_scan_guard.py
rtk uv run --python 3.14 --locked --extra dev python scripts/dev/export_v1_openapi.py --check
```

Results: Python 3.12 `10 passed in 0.97s`; Python 3.14 `10 passed in 2.32s`; both exporter checks exit 0.

An isolated real FastAPI 0.115.0 run passed the fallback, security, and 25-operation tenant tests: `3 passed in 1.80s`. Context7 documentation lookup was attempted first but unavailable because its monthly quota was exhausted; installed FastAPI 0.141.1 source and isolated FastAPI 0.115.0 package behavior supplied the compatibility evidence.

Fresh Python 3.12 and 3.14 renders and the checked-in golden remain byte-identical (`cmp` exit 0), each with SHA-256 `3bc972b283e83602fc87e1540b7a144e302d168f0e3ab0d2ba81069ebc855d0d`.

`rtk make verify` exits 0: Python `348 passed, 5 skipped, 1 pre-existing warning in 5.11s`; Go race, OpenTofu, and Compose gates pass. `git diff --check` exits 0 and the PR still changes exactly the six owned paths.

## Additional no-Scan alias hardening

Commit: `54125c1cdd5917b9d2dc60cbb67874850eeaa362`

The Go guard now derives the actual package identifier from direct or grouped imports of `github.com/aws/aws-sdk-go-v2/service/dynamodb`. It therefore rejects calls such as `ddb.NewScanPaginator(` and the repository's normal `awssdk` alias, while still rejecting direct imports and `.Scan(` calls. `_test.go` files remain excluded. Comments, block comments, interpreted strings, raw strings, and rune literals are blanked before call matching to avoid source-text false positives.

TDD evidence:

```text
RED: aliased grouped import expected internal/store.go, received []; 1 failed in 0.04s
GREEN: no-Scan guard suite 5 passed in 0.18s
```

Verification:

```text
Python 3.12 focused: 11 passed in 2.23s; exporter --check exit 0
Python 3.14 focused: 11 passed in 2.36s; exporter --check exit 0
make verify: exit 0; Python 349 passed, 5 skipped, 1 pre-existing warning in 5.13s
Go race, OpenTofu, and Compose gates: exit 0
git diff --check: exit 0
Ownership: exactly the six Issue #29-owned paths
```

## Dot-import call-context refinement

Commit: `18eb7ec401a9eed81d12c6837598711fb56faa50`

With a DynamoDB dot import, `NewScanPaginator(` is now classified by its lexical prefix rather than a one-character lookbehind. A candidate is ignored when it is:

- a local function/method declaration (`func NewScanPaginator` or `func (receiver) NewScanPaginator`); or
- a selector qualified by another package, including whitespace or a normalized comment after the dot.

An actually unqualified `NewScanPaginator(` call remains prohibited. All prior canonical, alias, grouped-import, dot-import, raw-string, comments/strings, `.Scan(`, and `_test.go` cases remain covered.

TDD evidence on the preceding head:

```text
local method RED: expected [], received internal/allowed.go; 1 failed in 0.04s
qualified selector RED: expected [], received internal/allowed.go; 1 failed in 0.03s
GREEN: both regressions 2 passed in 0.03s; full no-Scan guard 9 passed in 0.22s
```

Verification:

```text
Python 3.12 focused: 15 passed in 2.56s; exporter --check exit 0
Python 3.14 focused: 15 passed in 2.80s; exporter --check exit 0
make verify: exit 0; Python 353 passed, 5 skipped, 1 pre-existing warning in 5.95s
Go race, OpenTofu, and Compose gates: exit 0
git diff --check: exit 0
Ownership: exactly the six Issue #29-owned paths
```

## Prior dot-import and raw-string hardening

Commit: `ca56f4e2e5831352492aa1f716b6857618011e3e`

Two final no-Scan edge cases are covered:

- a valid dot import of the AWS SDK v2 DynamoDB package now causes an unqualified `NewScanPaginator(` call to be rejected;
- strings are tokenized before import extraction. Only a string or raw-string token whose complete value is the exact DynamoDB import path becomes an import marker, so a multiline raw string cannot manufacture an import declaration or bind an unrelated alias.

Canonical imports, explicit aliases, grouped imports, real raw-string import paths, comments/string suppression, `.Scan(` detection, and `_test.go` exclusion continue through the same guard.

TDD evidence on the preceding head:

```text
dot import RED: expected internal/store.go, received []; 1 failed in 0.03s
raw-string RED: expected [], received internal/allowed.go; 1 failed in 0.03s
GREEN: no-Scan guard suite 7 passed in 0.19s
```

Verification:

```text
Python 3.12 focused: 13 passed in 2.20s; exporter --check exit 0
Python 3.14 focused: 13 passed in 2.40s; exporter --check exit 0
make verify: exit 0; Python 351 passed, 5 skipped, 1 pre-existing warning in 5.10s
Go race, OpenTofu, and Compose gates: exit 0
git diff --check: exit 0
Ownership: exactly the six Issue #29-owned paths
```
